### PR TITLE
DM-35624: Create a task in analysis_tools to measure per-visit metrics

### DIFF
--- a/python/lsst/analysis/tools/actions/vector/selectors.py
+++ b/python/lsst/analysis/tools/actions/vector/selectors.py
@@ -133,6 +133,10 @@ class CoaddPlotFlagSelector(FlagSelector):
 
 
 class VisitPlotFlagSelector(FlagSelector):
+    """Select on a set of flags appropriate for making visit-level plots
+    (i.e., using sourceTable_visit catalogs).
+    """
+
     def getInputSchema(self) -> KeyedDataSchema:
         yield from super().getInputSchema()
 

--- a/python/lsst/analysis/tools/actions/vector/selectors.py
+++ b/python/lsst/analysis/tools/actions/vector/selectors.py
@@ -132,11 +132,35 @@ class CoaddPlotFlagSelector(FlagSelector):
         self.selectWhenTrue = ["detect_isPatchInner", "detect_isDeblendedSource"]
 
 
+class VisitPlotFlagSelector(FlagSelector):
+    def getInputSchema(self) -> KeyedDataSchema:
+        yield from super().getInputSchema()
+
+    def __call__(self, data: KeyedData, **kwargs) -> Vector:
+        result: Optional[Vector] = None
+        temp = super().__call__(data, **kwargs)
+        if result is not None:
+            result &= temp  # type: ignore
+        else:
+            result = temp
+
+        return result
+
+    def setDefaults(self):
+        self.selectWhenFalse = [
+            "psfFlux_flag",
+            "pixelFlags_saturatedCenter",
+            "extendedness_flag",
+            "centroid_flag",
+        ]
+
+
 class SnSelector(VectorAction):
     """Selects points that have S/N > threshold in the given flux type"""
 
     fluxType = Field[str](doc="Flux type to calculate the S/N in.", default="{band}_psfFlux")
     threshold = Field[float](doc="The S/N threshold to remove sources with.", default=500.0)
+    maxSN = Field[float](doc="Maximum S/N to include in the sample (to allow S/N ranges).", default=1e6)
     uncertaintySuffix = Field[str](
         doc="Suffix to add to fluxType to specify uncertainty column", default="Err"
     )
@@ -175,7 +199,8 @@ class SnSelector(VectorAction):
         for band in bands:
             fluxCol = self.fluxType.format(**(kwargs | dict(band=band)))
             errCol = f"{fluxCol}{self.uncertaintySuffix.format(**kwargs)}"
-            temp = (cast(Vector, data[fluxCol]) / data[errCol]) > self.threshold  # type: ignore
+            vec = cast(Vector, data[fluxCol]) / data[errCol]
+            temp = (vec > self.threshold) & (vec < self.maxSN)
             if mask is not None:
                 mask &= temp  # type: ignore
             else:
@@ -186,6 +211,8 @@ class SnSelector(VectorAction):
 
 
 class SkyObjectSelector(FlagSelector):
+    """Selects sky objects in the given band(s)"""
+
     bands = ListField[str](
         doc="The bands to apply the flags in, takes precedence if band supplied in kwargs",
         default=["i"],
@@ -221,6 +248,28 @@ class SkyObjectSelector(FlagSelector):
         self.selectWhenTrue = ["sky_object"]
 
 
+class SkySourceSelector(FlagSelector):
+    """Selects sky sources from sourceTables"""
+
+    def getInputSchema(self) -> KeyedDataSchema:
+        yield from super().getInputSchema()
+
+    def __call__(self, data: KeyedData, **kwargs) -> Vector:
+        result: Optional[Vector] = None
+        temp = super().__call__(data, **(kwargs))
+        if result is not None:
+            result &= temp  # type: ignore
+        else:
+            result = temp
+        return result
+
+    def setDefaults(self):
+        self.selectWhenFalse = [
+            "pixelFlags_edge",
+        ]
+        self.selectWhenTrue = ["sky_source"]
+
+
 class ExtendednessSelector(VectorAction):
     vectorKey = Field[str](
         doc="Key of the Vector which defines extendedness metric", default="{band}_extendedness"
@@ -241,7 +290,7 @@ class StarSelector(ExtendednessSelector):
 
     def __call__(self, data: KeyedData, **kwargs) -> Vector:
         extendedness = super().__call__(data, **kwargs)
-        return cast(Vector, (extendedness >= 0) & (extendedness < self.extendedness_maximum))  # type: ignore
+        return np.array(cast(Vector, (extendedness >= 0) & (extendedness < self.extendedness_maximum)))
 
 
 class GalaxySelector(ExtendednessSelector):

--- a/python/lsst/analysis/tools/analysisMetrics/__init__.py
+++ b/python/lsst/analysis/tools/analysisMetrics/__init__.py
@@ -18,4 +18,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from .limitingMagnitudeMetric import *
 from .metricMeasurementBundle import MetricMeasurementBundle
+from .skyFluxStatisticMetrics import *

--- a/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from ..actions.keyedData.stellarLocusFit import StellarLocusFitAction
 from ..actions.plot.scatterplotWithTwoHists import ScatterPlotStatsAction
-from ..actions.scalar.scalarActions import ApproxFloor, MeanAction, MedianAction, SigmaMadAction, StdevAction
+from ..actions.scalar.scalarActions import ApproxFloor
 from ..actions.vector import (
     CalcShapeSize,
     CoaddPlotFlagSelector,
@@ -30,7 +30,6 @@ from ..actions.vector import (
     ExtinctionCorrectedMagDiff,
     FractionalDifference,
     MagColumnNanoJansky,
-    SkyObjectSelector,
     SnSelector,
     StarSelector,
     VectorSelector,
@@ -267,27 +266,4 @@ class XPerpPSFMetric(AnalysisMetric):
 
         self.produce.units = {  # type: ignore
             "wPerp_sigmaMAD": "mag",  # TODO need to return mmag from wPerp
-        }
-
-
-class SkyFluxStatisticMetric(AnalysisMetric):
-    parameterizedBand: bool = True
-    fluxType: str = "ap09Flux"
-
-    def setDefaults(self):
-        super().setDefaults()
-
-        self.prep.selectors.skyObjectSelector = SkyObjectSelector()
-        self.prep.selectors.skyObjectSelector.bands = ["{band}"]
-
-        self.process.calculateActions.medianSky = MedianAction(vectorKey=f"{{band}}_{self.fluxType}")
-        self.process.calculateActions.meanSky = MeanAction(vectorKey=f"{{band}}_{self.fluxType}")
-        self.process.calculateActions.stdevSky = StdevAction(vectorKey=f"{{band}}_{self.fluxType}")
-        self.process.calculateActions.sigmaMADSky = SigmaMadAction(vectorKey=f"{{band}}_{self.fluxType}")
-
-        self.produce.units = {  # type: ignore
-            "medianSky": "nJy",
-            "meanSky": "nJy",
-            "stdevSky": "nJy",
-            "sigmaMADSky": "nJy",
         }

--- a/python/lsst/analysis/tools/analysisMetrics/limitingMagnitudeMetric.py
+++ b/python/lsst/analysis/tools/analysisMetrics/limitingMagnitudeMetric.py
@@ -29,6 +29,13 @@ from ..interfaces import AnalysisMetric
 
 
 class FiveSigmaPointSourceDepthMetric(AnalysisMetric):
+    """Calculate the five-sigma point source depth of a visit, based on the
+    PSF flux and its reported error. By default the calculation selects
+    objects between 4.75 < S/N < 5.25, but these limits are configurable.
+    The flux type to use for selection is also configurable. Both the median
+    and mean 5-sigma depths are returned.
+    """
+
     parameterizedBand: bool = False
 
     def setDefaults(self):

--- a/python/lsst/analysis/tools/analysisMetrics/limitingMagnitudeMetric.py
+++ b/python/lsst/analysis/tools/analysisMetrics/limitingMagnitudeMetric.py
@@ -1,0 +1,53 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ("FiveSigmaPointSourceDepthMetric",)
+
+from ..actions.scalar.scalarActions import MeanAction, MedianAction
+from ..actions.vector.selectors import SnSelector, StarSelector
+from ..actions.vector.vectorActions import MagColumnNanoJansky
+from ..interfaces import AnalysisMetric
+
+
+class FiveSigmaPointSourceDepthMetric(AnalysisMetric):
+    parameterizedBand: bool = False
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        self.prep.selectors.starSelector = StarSelector()
+        self.prep.selectors.starSelector.columnKey = "extendedness"
+
+        self.prep.selectors.snSelector = SnSelector()
+        self.prep.selectors.snSelector.fluxType = "psfFlux"
+        # Select between 4.75 < SNR < 5.25 to get a decent sample:
+        self.prep.selectors.snSelector.threshold = 4.75
+        self.prep.selectors.snSelector.maxSN = 5.25
+
+        self.process.buildActions.mags = MagColumnNanoJansky(vectorKey="psfFlux")
+        self.process.calculateActions.median5sigmaDepth = MedianAction(colKey="mags")
+        self.process.calculateActions.mean5sigmaDepth = MeanAction(colKey="mags")
+
+        self.produce.units = {  # type: ignore
+            "median5sigmaDepth": "mag",
+            "mean5sigmaDepth": "mag",
+        }

--- a/python/lsst/analysis/tools/analysisMetrics/skyFluxStatisticMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/skyFluxStatisticMetrics.py
@@ -1,0 +1,74 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ("SkyFluxStatisticMetric", "SkyFluxVisitStatisticMetric")
+
+from ..actions.scalar.scalarActions import MeanAction, MedianAction, SigmaMadAction, StdevAction
+from ..actions.vector.selectors import SkyObjectSelector, SkySourceSelector
+from ..interfaces import AnalysisMetric
+
+
+class SkyFluxStatisticMetric(AnalysisMetric):
+    # Calculate sky flux statistics on objectTable
+    parameterizedBand: bool = True
+    fluxType: str = "ap09Flux"
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        self.prep.selectors.skyObjectSelector = SkyObjectSelector()
+        self.prep.selectors.skyObjectSelector.bands = ["{band}"]
+
+        self.process.calculateActions.medianSky = MedianAction(colKey=f"{{band}}_{self.fluxType}")
+        self.process.calculateActions.meanSky = MeanAction(colKey=f"{{band}}_{self.fluxType}")
+        self.process.calculateActions.stdevSky = StdevAction(colKey=f"{{band}}_{self.fluxType}")
+        self.process.calculateActions.sigmaMADSky = SigmaMadAction(colKey=f"{{band}}_{self.fluxType}")
+
+        self.post_process.units = {  # type: ignore
+            "medianSky": "nJy",
+            "meanSky": "nJy",
+            "stdevSky": "nJy",
+            "sigmaMADSky": "nJy",
+        }
+
+
+class SkyFluxVisitStatisticMetric(AnalysisMetric):
+    # Calculate sky flux statistics on sourceTable (i.e., per visit)
+    parameterizedBand: bool = False
+    fluxType: str = "ap09Flux"
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        self.prep.selectors.skySourceSelector = SkySourceSelector()
+
+        self.process.calculateActions.medianSky = MedianAction(colKey=f"{self.fluxType}")
+        self.process.calculateActions.meanSky = MeanAction(colKey=f"{self.fluxType}")
+        self.process.calculateActions.stdevSky = StdevAction(colKey=f"{self.fluxType}")
+        self.process.calculateActions.sigmaMADSky = SigmaMadAction(colKey=f"{self.fluxType}")
+
+        self.produce.units = {  # type: ignore
+            "medianSky": "nJy",
+            "meanSky": "nJy",
+            "stdevSky": "nJy",
+            "sigmaMADSky": "nJy",
+        }

--- a/python/lsst/analysis/tools/analysisMetrics/skyFluxStatisticMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/skyFluxStatisticMetrics.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = "SkyFluxStatisticMetric"
+__all__ = ("SkyFluxStatisticMetric",)
 
 from ..actions.scalar.scalarActions import MeanAction, MedianAction, SigmaMadAction, StdevAction
 from ..actions.vector.selectors import SkyObjectSelector, SkySourceSelector
@@ -28,7 +28,12 @@ from ..interfaces import AnalysisMetric
 
 
 class SkyFluxStatisticMetric(AnalysisMetric):
-    # Calculate sky flux statistics on objectTable
+    """Calculate sky flux statistics. This uses the 9-pixel aperture flux for
+    sky sources/objects, and returns multiple statistics on the measured
+    fluxes. Note that either visitContext (measurement on sourceTable) or
+    coaddContext (measurement on objectTable) must be specified.
+    """
+
     parameterizedBand: bool = True
     fluxType: str = "ap09Flux"
 

--- a/python/lsst/analysis/tools/analysisMetrics/skyFluxStatisticMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/skyFluxStatisticMetrics.py
@@ -20,12 +20,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = ("SkyFluxStatisticMetric", "SkyFluxVisitStatisticMetric")
+__all__ = "SkyFluxStatisticMetric"
 
-from ..actions.keyedData.skyFluxStatistic import SkyFluxStatisticAction
 from ..actions.scalar.scalarActions import MeanAction, MedianAction, SigmaMadAction, StdevAction
 from ..actions.vector.selectors import SkyObjectSelector, SkySourceSelector
-from ..contexts import Context
 from ..interfaces import AnalysisMetric
 
 
@@ -51,55 +49,6 @@ class SkyFluxStatisticMetric(AnalysisMetric):
 
     def setDefaults(self):
         super().setDefaults()
-
-        self.produce.units = {  # type: ignore
-            "medianSky": "nJy",
-            "meanSky": "nJy",
-            "stdevSky": "nJy",
-            "sigmaMADSky": "nJy",
-        }
-
-
-"""
-class SkyFluxStatisticMetric(AnalysisMetric):
-    # Calculate sky flux statistics on objectTable
-    parameterizedBand: bool = True
-    fluxType: str = "ap09Flux"
-
-    def setDefaults(self):
-        super().setDefaults()
-
-        self.prep.selectors.skyObjectSelector = SkyObjectSelector()
-        self.prep.selectors.skyObjectSelector.bands = ["{band}"]
-
-        self.process.calculateActions.medianSky = MedianAction(colKey=f"{{band}}_{self.fluxType}")
-        self.process.calculateActions.meanSky = MeanAction(colKey=f"{{band}}_{self.fluxType}")
-        self.process.calculateActions.stdevSky = StdevAction(colKey=f"{{band}}_{self.fluxType}")
-        self.process.calculateActions.sigmaMADSky = SigmaMadAction(colKey=f"{{band}}_{self.fluxType}")
-
-        self.produce.units = {  # type: ignore
-            "medianSky": "nJy",
-            "meanSky": "nJy",
-            "stdevSky": "nJy",
-            "sigmaMADSky": "nJy",
-        }
-"""
-
-
-class SkyFluxVisitStatisticMetric(AnalysisMetric):
-    # Calculate sky flux statistics on sourceTable (i.e., per visit)
-    parameterizedBand: bool = False
-    fluxType: str = "ap09Flux"
-
-    def setDefaults(self):
-        super().setDefaults()
-
-        self.prep.selectors.skySourceSelector = SkySourceSelector()
-
-        self.process.calculateActions.medianSky = MedianAction(colKey=f"{self.fluxType}")
-        self.process.calculateActions.meanSky = MeanAction(colKey=f"{self.fluxType}")
-        self.process.calculateActions.stdevSky = StdevAction(colKey=f"{self.fluxType}")
-        self.process.calculateActions.sigmaMADSky = SigmaMadAction(colKey=f"{self.fluxType}")
 
         self.produce.units = {  # type: ignore
             "medianSky": "nJy",

--- a/python/lsst/analysis/tools/interfaces.py
+++ b/python/lsst/analysis/tools/interfaces.py
@@ -306,23 +306,6 @@ class AnalysisTool(AnalysisAction):
     produce a result for multiple bands.
     """
 
-    def applyContext(self, context: ContextType) -> None:
-        r"""Apply a `Context` to this `AnalysisTool`.
-
-        `Context`\ s are specific execution environments that allow any
-        `AnalysisActions` specified within an `AnalysisTool` to be
-        automatically configured if they are aware of the execution context.
-
-        Parameters
-        ----------
-        context : `Context`
-            The specific execution context, this may be a single context or
-            a joint context, see `Context` for more info.
-        """
-        self.prep.applyContext(context)
-        self.process.applyContext(context)
-        self.produce.applyContext(context)
-
     def __call__(
         self, data: KeyedData, **kwargs
     ) -> Mapping[str, Figure] | Figure | Mapping[str, Measurement] | Measurement:

--- a/python/lsst/analysis/tools/tasks/objectTableTractAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/objectTableTractAnalysis.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from lsst.pipe.base import connectionTypes as ct
 
 from ..analysisMetrics.analysisMetrics import ShapeSizeFractionalMetric
+from ..analysisMetrics.skyFluxStatisticMetrics import SkyFluxStatisticMetric
 from ..analysisPlots.analysisPlots import Ap12PsfSkyPlot, ShapeSizeFractionalDiffScatter
 from .base import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 
@@ -52,6 +53,7 @@ class ObjectTableTractAnalysisConfig(
 
         # set metrics to run
         self.metrics.shapeSizeFractionalMetric = ShapeSizeFractionalMetric()
+        self.metrics.skyFluxStatisticMetric = SkyFluxStatisticMetric()
 
 
 class ObjectTableTractAnalysisTask(AnalysisPipelineTask):

--- a/python/lsst/analysis/tools/tasks/objectTableTractAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/objectTableTractAnalysis.py
@@ -25,6 +25,7 @@ from lsst.pipe.base import connectionTypes as ct
 from ..analysisMetrics.analysisMetrics import ShapeSizeFractionalMetric
 from ..analysisMetrics.skyFluxStatisticMetrics import SkyFluxStatisticMetric
 from ..analysisPlots.analysisPlots import Ap12PsfSkyPlot, ShapeSizeFractionalDiffScatter
+from ..contexts import CoaddContext
 from .base import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 
 
@@ -54,6 +55,7 @@ class ObjectTableTractAnalysisConfig(
         # set metrics to run
         self.metrics.shapeSizeFractionalMetric = ShapeSizeFractionalMetric()
         self.metrics.skyFluxStatisticMetric = SkyFluxStatisticMetric()
+        self.metrics.skyFluxStatisticMetric.applyContext(CoaddContext)
 
 
 class ObjectTableTractAnalysisTask(AnalysisPipelineTask):

--- a/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from lsst.pipe.base import connectionTypes as ct
 
-from ..analysisMetrics.analysisMetrics import ShapeSizeFractionalMetric
-from ..analysisPlots.analysisPlots import ShapeSizeFractionalDiffScatter
-
-# from ..vectorActions.selectors import VisitPlotFlagSelector
+from ..analysisMetrics.limitingMagnitudeMetric import FiveSigmaPointSourceDepthMetric
+from ..analysisMetrics.skyFluxStatisticMetrics import SkyFluxVisitStatisticMetric
 from .base import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 
 
@@ -30,12 +28,10 @@ class SourceTableVisitAnalysisConfig(
     def setDefaults(self):
         super().setDefaults()
         # set plots to run
-        self.plots.shapeSizeFractionalDiffScatter = ShapeSizeFractionalDiffScatter()
-        # self.plots.shapeSizeFractionalDiffScatter.flagSelector = \
-        # VisitPlotFlagSelector()
 
         # set metrics to run
-        self.metrics.shapeSizeFractionalMetric = ShapeSizeFractionalMetric()
+        self.metrics.fiveSigmaPointSourceDepthMetric = FiveSigmaPointSourceDepthMetric()
+        self.metrics.skyFluxVisitStatisticMetric = SkyFluxVisitStatisticMetric()
 
 
 class SourceTableVisitAnalysisTask(AnalysisPipelineTask):

--- a/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from lsst.pipe.base import connectionTypes as ct
 
+from ..analysisMetrics import SkyFluxStatisticMetric
 from ..analysisMetrics.limitingMagnitudeMetric import FiveSigmaPointSourceDepthMetric
-from ..analysisMetrics.skyFluxStatisticMetrics import SkyFluxVisitStatisticMetric
+from ..contexts import VisitContext
 from .base import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 
 
@@ -31,7 +32,8 @@ class SourceTableVisitAnalysisConfig(
 
         # set metrics to run
         self.metrics.fiveSigmaPointSourceDepthMetric = FiveSigmaPointSourceDepthMetric()
-        self.metrics.skyFluxVisitStatisticMetric = SkyFluxVisitStatisticMetric()
+        self.metrics.skyFluxVisitStatisticMetric = SkyFluxStatisticMetric()
+        self.metrics.skyFluxVisitStatisticMetric.applyContext(VisitContext)
 
 
 class SourceTableVisitAnalysisTask(AnalysisPipelineTask):

--- a/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from lsst.pipe.base import connectionTypes as ct
 
-from ..analysisMetrics import SkyFluxStatisticMetric
 from ..analysisMetrics.limitingMagnitudeMetric import FiveSigmaPointSourceDepthMetric
+from ..analysisMetrics.skyFluxStatisticMetrics import SkyFluxStatisticMetric
 from ..contexts import VisitContext
 from .base import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 


### PR DESCRIPTION
In addition to the 5-sigma limiting magnitude calculation, I also added sky source statistics. For the sky stats, I moved them into their own standalone file containing both the objectTable and sourceTable versions.