### PR TITLE
DM-35614: Add Contexts

### DIFF
--- a/python/lsst/analysis/tools/contexts/__init__.py
+++ b/python/lsst/analysis/tools/contexts/__init__.py
@@ -1,0 +1,60 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+r"""The context module provides the tooling to define various execution
+contexts.
+
+Execution contexts are defined by creating a subclass of `Context`. By
+Convention the name of the subclass should be <Name>Context.
+
+Multiple contexts can be joined together to create an extended Context by
+or-ing them together i.e.
+
+compoundContext = VisitContext | PlotContext
+
+A `Context` is applied to an `AnalysisAction` by calling ``applyContext`` and 
+passing in a context. The `AnalysisAction` will then see if it has
+corresponding method (the name of the context with the first letter lower case
+i.e. visitContext). If a method is present, it will be called to activate the
+context for that `AnalysisAction`. The action will then recursively walk down
+through any  subsequent actions calling ``applyContext``.
+
+When the context being applied is some compound context, a call to
+``applyContext`` will happen for each `Context` individually. The variable name
+of the compound `Context` is not important, and in some cases is unneeded i.e.
+
+analysis.applyContext(VisitContext | PlotContext)
+
+This is equivalent to:
+
+analysis.applyContext(VisitContext)
+analysis.applyContext(PlotContext)
+
+But the ability to store multiple `Context`\ s in a variable can be useful when
+linking multiple `AnalysisTool`\ s together, or creating a context that might
+be frequently reused.
+
+An `AnalysisAction` is entirely in control to what it does when it enters a
+`Context` or if it even responds at all based on if it implements the context
+method, and what it does inside that method.
+"""
+
+from ._baseContext import *
+from ._contexts import *

--- a/python/lsst/analysis/tools/contexts/_baseContext.py
+++ b/python/lsst/analysis/tools/contexts/_baseContext.py
@@ -1,0 +1,179 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+"""This is a module which defines all the implementation details for the
+`Context` base class.
+"""
+
+__all__ = ("ContextMeta", "Context", "ContextType")
+
+from typing import TYPE_CHECKING, Callable, Iterable, Union, cast
+
+if TYPE_CHECKING:
+    from ..interfaces import AnalysisAction
+
+
+class GetterStandin:
+    def __init__(self, base: Union[Context, ContextMeta]):
+        self.base = base
+
+    def __call__(self) -> Iterable[ContextMeta]:
+        return self.base._contexts
+
+
+class ContextGetter:
+    r"""Return all the individual `Context\ s` that are part of an overall
+    `Context`.
+
+    In the case of a single `Context` subclass, this will be a
+    set with one element. If the `Context` is a joint `Context` (created
+    from more than one individual `Context`\ s, this will be a set of all
+    joined `Context`\ s.
+
+    Returns
+    -------
+    result : `typing.Iterable` of `ContextMeta`
+    """
+
+    def __get__(self, instance, klass) -> Callable[..., Iterable[ContextMeta]]:
+        if instance is not None:
+            return GetterStandin(instance)
+        else:
+            return GetterStandin(klass)
+
+
+class ContextMeta(type):
+    """Metaclass for `Context`, this handles ensuring singleton behavior for
+    each `Context`. It also provides the functionality of joining contexts
+    together using the | operator.
+    """
+
+    _contexts: set[ContextMeta]
+
+    def __new__(cls, *args, **kwargs):
+        result = cast(ContextMeta, super().__new__(cls, *args, *kwargs))
+        result._contexts = set()
+        if result.__name__ != "Context":
+            result._contexts.add(result)
+        return result
+
+    def apply(cls, action: AnalysisAction) -> None:
+        """Apply this context to a given `AnalysisAction`
+
+        This method checks to see if an `AnalysisAction` is aware of this
+        `Context`. If it is it calls the actions context method (the class name
+        with the first letter lower case)
+
+        Parameters
+        ----------
+        action : `AnalysisAction`
+            The action to apply the `Context` to.
+        """
+        name = cls.__name__
+        name = f"{name[0].lower()}{name[1:]}"
+        if hasattr(action, name):
+            getattr(action, name)()
+
+    # ignore the conflict with the super type, because we are doing a
+    # join
+    def __or__(cls, other: ContextMeta | Context) -> Context:  # type: ignore
+        """Join multiple Contexts together into a new `Context` instance.
+
+        Parameters
+        ----------
+        other : `ContextMeta` or `Context`
+           #The other `context` to join together with the current `Context`
+
+        Returns
+        -------
+        jointContext : `Context`
+           #A `Context` that is the join of this `Context` and the other.
+        """
+        if not isinstance(other, (Context, ContextMeta)):
+            raise NotImplementedError()
+        ctx = Context()
+        ctx._contexts = set()
+        ctx._contexts |= cls._contexts
+        ctx._contexts |= other._contexts
+        return ctx
+
+    @staticmethod
+    def _makeStr(obj: Union[Context, ContextMeta]) -> str:
+        ctxs = list(obj.getContexts())
+        if len(ctxs) == 1:
+            return ctxs[0].__name__
+        else:
+            return "|".join(ctx.__name__ for ctx in ctxs)
+
+    def __str__(cls) -> str:
+        return cls._makeStr(cls)
+
+    def __repr__(cls) -> str:
+        return str(cls)
+
+    getContexts = ContextGetter()
+
+
+class Context(metaclass=ContextMeta):
+    """A Base Context class.
+
+    Instances of this class are used to hold joins of multiple contexts.
+
+    Subclassing this class creates a new independent context.
+    """
+
+    _contexts: set[ContextMeta]
+
+    getContexts = ContextGetter()
+
+    def __str__(self) -> str:
+        return type(self)._makeStr(self)
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __or__(self, other: type[Context] | Context) -> Context:
+        """Join multiple Contexts together into a new `Context` instance.
+
+        Parameters
+        ----------
+        other : `ContextMeta` or `Context`
+            The other `context` to join together with the current `Context`
+
+        Returns
+        -------
+        jointContext : `Context`
+            A `Context` that is the join of this `Context` and the other.
+        """
+        if not isinstance(other, (Context, ContextMeta)):
+            raise NotImplementedError()
+        ctx = Context()
+        ctx._contexts = set()
+        ctx._contexts |= self._contexts
+        ctx._contexts |= other._contexts
+        return ctx
+
+
+ContextType = Union[Context, type[Context]]
+"""A type alias to use in contexts where either a Context type or instance
+should be accepted (which is most places)
+"""

--- a/python/lsst/analysis/tools/contexts/_contexts.py
+++ b/python/lsst/analysis/tools/contexts/_contexts.py
@@ -1,0 +1,44 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+"""This is a module where concrete Contexts should be defined. These should
+be a subclass of `Context`, and should contain a description of what the
+context is for as it's docstring.
+"""
+
+from ._baseContext import Context
+
+
+class VisitContext(Context):
+    """A context which indicates `AnalysisActions are being run in the context
+    of visit level data.
+    """
+
+    pass
+
+
+class CoaddContext(Context):
+    """A context which indicates `AnalysisActions are being run in the context
+    of coadd level data.
+    """
+
+    pass

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -1,0 +1,177 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+import warnings
+from typing import cast
+from unittest import TestCase, main
+
+import lsst.utils.tests
+import numpy as np
+from lsst.analysis.tools import (
+    AnalysisAction,
+    AnalysisTool,
+    KeyedData,
+    KeyedDataAction,
+    KeyedDataSchema,
+    Scalar,
+    ScalarAction,
+    Vector,
+)
+from lsst.analysis.tools.actions.scalar import MeanAction, MedianAction
+from lsst.analysis.tools.contexts import Context
+from lsst.pex.config import Field
+from lsst.pipe.tasks.configurableActions import ConfigurableActionField, ConfigurableActionStructField
+
+
+class MedianContext(Context):
+    """Test Context for median"""
+
+    pass
+
+
+class MeanContext(Context):
+    """Test Context for mean"""
+
+    pass
+
+
+class MultiplyContext(Context):
+    """Test Context to multiply results"""
+
+    pass
+
+
+class DivideContext(Context):
+    """Test Context to divide result"""
+
+    pass
+
+
+class TestAction1(KeyedDataAction):
+    multiple = ConfigurableActionStructField[ScalarAction](doc="Multiple Actions")
+
+    def getInputSchema(self) -> KeyedDataSchema:
+        return (("a", Vector),)
+
+    def medianContext(self) -> None:
+        self.multiple.a = MedianAction(colKey="a")
+        self.multiple.b = MedianAction(colKey="a")
+        self.multiple.c = MedianAction(colKey="a")
+
+    def meanContext(self) -> None:
+        self.multiple.a = MeanAction(colKey="a")
+        self.multiple.b = MeanAction(colKey="a")
+
+    def __call__(self, data: KeyedData, **kwargs) -> KeyedData:
+        result = np.array([action(data, **kwargs) for action in self.multiple])
+        return cast(KeyedData, {"b": result})
+
+
+class TestAction2(KeyedDataAction):
+    single = ConfigurableActionField[ScalarAction](doc="Single Action")
+    multiplier = ConfigurableActionField[AnalysisAction](doc="Multiplier")
+
+    def getInputSchema(self) -> KeyedDataSchema:
+        return (("b", Vector),)
+
+    def setDefaults(self) -> None:
+        super().setDefaults()
+        # This action remains constant in every context, but it will be
+        # recursively configured with any contexts
+        self.multiplier = TestAction3()
+
+    def medianContext(self) -> None:
+        self.single = MedianAction(colKey="b")
+
+    def meanContext(self) -> None:
+        self.single = MeanAction(colKey="b")
+
+    def __call__(self, data: KeyedData, **kwargs) -> KeyedData:
+        result = self.single(data, **kwargs)
+        result *= cast(Scalar, self.multiplier(cast(KeyedData, {"c": result}), **kwargs)["d"])
+        return {"c": result}
+
+
+class TestAction3(KeyedDataAction):
+    multiplier = Field[float](doc="Number to multiply result by")
+
+    def getInputSchema(self) -> KeyedDataSchema:
+        return (("c", Vector),)
+
+    def multiplyContext(self):
+        self.multiplier = 2
+
+    def divideContext(self):
+        self.multiplier = 0.5
+
+    def __call__(self, data: KeyedData, **kwargs) -> KeyedData:
+        return {"d": cast(Scalar, data["c"]) * self.multiplier}
+
+
+class TestAnalysisTool(AnalysisTool):
+    def setDefaults(self) -> None:
+        self.prep = TestAction1()
+        self.process = TestAction2()
+        self.produce = TestAction3()
+
+
+class ContextTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.array = np.arange(20)
+        self.input = cast(KeyedData, {"a": self.array})
+
+    def testContext1(self):
+        tester = TestAnalysisTool()
+        # test applying contexts serially
+        tester.applyContext(MultiplyContext())
+        tester.applyContext(MedianContext)
+        # cast below, because we are abusing AnalysisTool a bit for testing
+        # the final stage produces KeyedData instead of Measurement of Figure
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = cast(KeyedData, tester(self.input))
+        self.assertEqual(result["d"], 361)
+
+    def testContext2(self):
+        tester2 = TestAnalysisTool()
+        compound = MeanContext | DivideContext
+        tester2.applyContext(compound)
+        # cast below, because we are abusing AnalysisTool a bit for testing
+        # the final stage produces KeyedData instead of Measurement of Figure
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = cast(KeyedData, tester2(self.input))
+        self.assertEqual(result["d"], 22.5625)
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    main()


### PR DESCRIPTION
Add a feature which will allow specifying a context for
AnalysisTools to run within. Each AnalysisAction can specify a
behavior for if a context is entered. If no behavior is defined on
an AnalysisAction then nothing happens.