### PR TITLE
DM-37052: Implement metrics that calculate whether table columns are "well formed"

### DIFF
--- a/pipelines/coaddColumnValidate.yaml
+++ b/pipelines/coaddColumnValidate.yaml
@@ -1,0 +1,13 @@
+description: |
+  Tier 1 DRP metrics to assess table column validity
+tasks:
+  validateObjectTableCore:
+    class: lsst.analysis.tools.tasks.ObjectTableTractAnalysisTask
+    config:
+      bands: ['g', 'r', 'i', 'z', 'y']
+      connections.outputName: objectTableCore
+      metrics.validPsfFluxMetric: ValidFracColumnMetric
+      metrics.validPsfFluxMetric.applyContext: CoaddContext
+      python: |
+        from lsst.analysis.tools.analysisMetrics import *
+        from lsst.analysis.tools.contexts import *

--- a/pipelines/coaddColumnValidate.yaml
+++ b/pipelines/coaddColumnValidate.yaml
@@ -6,10 +6,10 @@ tasks:
     config:
       connections.outputName: objectTableColumnValidate
       metrics.validPsfFluxMetric: ValidFracColumnMetric
-      metrics.validPsfFluxMetric.vectorKey : 'psfFlux'
+      metrics.validPsfFluxMetric.vectorKey: 'psfFlux'
       metrics.validPsfFluxMetric.applyContext: CoaddContext
       metrics.validCmodelFluxMetric: ValidFracColumnMetric
-      metrics.validCmodelFluxMetric.vectorKey : 'cModelFlux'
+      metrics.validCmodelFluxMetric.vectorKey: 'cModelFlux'
       metrics.validCmodelFluxMetric.applyContext: CoaddContext
       python: |
         from lsst.analysis.tools.analysisMetrics import *

--- a/pipelines/coaddColumnValidate.yaml
+++ b/pipelines/coaddColumnValidate.yaml
@@ -7,7 +7,11 @@ tasks:
       bands: ['g', 'r', 'i', 'z', 'y']
       connections.outputName: objectTableCore
       metrics.validPsfFluxMetric: ValidFracColumnMetric
+      metrics.validPsfFluxMetric.vectorKey : 'psfFlux'
       metrics.validPsfFluxMetric.applyContext: CoaddContext
+      metrics.validCmodelFluxMetric: ValidFracColumnMetric
+      metrics.validCmodelFluxMetric.vectorKey : 'cModelFlux'
+      metrics.validCmodelFluxMetric.applyContext: CoaddContext
       python: |
         from lsst.analysis.tools.analysisMetrics import *
         from lsst.analysis.tools.contexts import *

--- a/pipelines/coaddColumnValidate.yaml
+++ b/pipelines/coaddColumnValidate.yaml
@@ -4,8 +4,7 @@ tasks:
   validateObjectTableCore:
     class: lsst.analysis.tools.tasks.ObjectTableTractAnalysisTask
     config:
-      bands: ['g', 'r', 'i', 'z', 'y']
-      connections.outputName: objectTableCore
+      connections.outputName: objectTableColumnValidate
       metrics.validPsfFluxMetric: ValidFracColumnMetric
       metrics.validPsfFluxMetric.vectorKey : 'psfFlux'
       metrics.validPsfFluxMetric.applyContext: CoaddContext

--- a/pipelines/visitColumnValidate.yaml
+++ b/pipelines/visitColumnValidate.yaml
@@ -4,8 +4,7 @@ tasks:
   validateSourceTableCore:
     class: lsst.analysis.tools.tasks.SourceTableVisitAnalysisTask
     config:
-      bands: ['g', 'r', 'i', 'z', 'y']
-      connections.outputName: visitTableCore
+      connections.outputName: visitTableColumnValidate
       metrics.validPsfFluxMetric: ValidFracColumnMetric
       metrics.validPsfFluxMetric.vectorKey : 'psfFlux'
       metrics.validPsfFluxMetric.applyContext: VisitContext

--- a/pipelines/visitColumnValidate.yaml
+++ b/pipelines/visitColumnValidate.yaml
@@ -9,9 +9,39 @@ tasks:
       metrics.validPsfFluxMetric: ValidFracColumnMetric
       metrics.validPsfFluxMetric.vectorKey : 'psfFlux'
       metrics.validPsfFluxMetric.applyContext: VisitContext
-      metrics.validCmodelFluxMetric: ValidFracColumnMetric
-      metrics.validCmodelFluxMetric.vectorKey : 'ap09Flux'
-      metrics.validCmodelFluxMetric.applyContext: VisitContext
+      metrics.validAp03FluxMetric: ValidFracColumnMetric
+      metrics.validAp03FluxMetric.vectorKey : 'ap03Flux'
+      metrics.validAp03FluxMetric.applyContext: VisitContext
+      metrics.validAp06FluxMetric: ValidFracColumnMetric
+      metrics.validAp06FluxMetric.vectorKey : 'ap06Flux'
+      metrics.validAp06FluxMetric.applyContext: VisitContext
+      metrics.validAp09FluxMetric: ValidFracColumnMetric
+      metrics.validAp09FluxMetric.vectorKey : 'ap09Flux'
+      metrics.validAp09FluxMetric.applyContext: VisitContext
+      metrics.validAp12FluxMetric: ValidFracColumnMetric
+      metrics.validAp12FluxMetric.vectorKey : 'ap12Flux'
+      metrics.validAp12FluxMetric.applyContext: VisitContext
+      metrics.validAp17FluxMetric: ValidFracColumnMetric
+      metrics.validAp17FluxMetric.vectorKey : 'ap17Flux'
+      metrics.validAp17FluxMetric.applyContext: VisitContext
+      metrics.validAp25FluxMetric: ValidFracColumnMetric
+      metrics.validAp25FluxMetric.vectorKey : 'ap25Flux'
+      metrics.validAp25FluxMetric.applyContext: VisitContext
+      metrics.validAp35FluxMetric: ValidFracColumnMetric
+      metrics.validAp35FluxMetric.vectorKey : 'ap35Flux'
+      metrics.validAp35FluxMetric.applyContext: VisitContext
+      metrics.validAp50FluxMetric: ValidFracColumnMetric
+      metrics.validAp50FluxMetric.vectorKey : 'ap50Flux'
+      metrics.validAp50FluxMetric.applyContext: VisitContext
+      metrics.validAp70FluxMetric: ValidFracColumnMetric
+      metrics.validAp70FluxMetric.vectorKey : 'ap70Flux'
+      metrics.validAp70FluxMetric.applyContext: VisitContext
+      metrics.validCalibFluxMetric: ValidFracColumnMetric
+      metrics.validCalibFluxMetric.vectorKey : 'calibFlux'
+      metrics.validCalibFluxMetric.applyContext: VisitContext
+      metrics.validGaussianFluxMetric: ValidFracColumnMetric
+      metrics.validGaussianFluxMetric.vectorKey : 'gaussianFlux'
+      metrics.validGaussianFluxMetric.applyContext: VisitContext
       python: |
         from lsst.analysis.tools.analysisMetrics import *
         from lsst.analysis.tools.contexts import *

--- a/pipelines/visitColumnValidate.yaml
+++ b/pipelines/visitColumnValidate.yaml
@@ -1,0 +1,17 @@
+description: |
+  Tier 1 DRP metrics to assess table column validity
+tasks:
+  validateSourceTableCore:
+    class: lsst.analysis.tools.tasks.SourceTableVisitAnalysisTask
+    config:
+      bands: ['g', 'r', 'i', 'z', 'y']
+      connections.outputName: visitTableCore
+      metrics.validPsfFluxMetric: ValidFracColumnMetric
+      metrics.validPsfFluxMetric.vectorKey : 'psfFlux'
+      metrics.validPsfFluxMetric.applyContext: VisitContext
+      metrics.validCmodelFluxMetric: ValidFracColumnMetric
+      metrics.validCmodelFluxMetric.vectorKey : 'ap09Flux'
+      metrics.validCmodelFluxMetric.applyContext: VisitContext
+      python: |
+        from lsst.analysis.tools.analysisMetrics import *
+        from lsst.analysis.tools.contexts import *

--- a/pipelines/visitColumnValidate.yaml
+++ b/pipelines/visitColumnValidate.yaml
@@ -6,40 +6,40 @@ tasks:
     config:
       connections.outputName: visitTableColumnValidate
       metrics.validPsfFluxMetric: ValidFracColumnMetric
-      metrics.validPsfFluxMetric.vectorKey : 'psfFlux'
+      metrics.validPsfFluxMetric.vectorKey: 'psfFlux'
       metrics.validPsfFluxMetric.applyContext: VisitContext
       metrics.validAp03FluxMetric: ValidFracColumnMetric
-      metrics.validAp03FluxMetric.vectorKey : 'ap03Flux'
+      metrics.validAp03FluxMetric.vectorKey: 'ap03Flux'
       metrics.validAp03FluxMetric.applyContext: VisitContext
       metrics.validAp06FluxMetric: ValidFracColumnMetric
-      metrics.validAp06FluxMetric.vectorKey : 'ap06Flux'
+      metrics.validAp06FluxMetric.vectorKey: 'ap06Flux'
       metrics.validAp06FluxMetric.applyContext: VisitContext
       metrics.validAp09FluxMetric: ValidFracColumnMetric
-      metrics.validAp09FluxMetric.vectorKey : 'ap09Flux'
+      metrics.validAp09FluxMetric.vectorKey: 'ap09Flux'
       metrics.validAp09FluxMetric.applyContext: VisitContext
       metrics.validAp12FluxMetric: ValidFracColumnMetric
-      metrics.validAp12FluxMetric.vectorKey : 'ap12Flux'
+      metrics.validAp12FluxMetric.vectorKey: 'ap12Flux'
       metrics.validAp12FluxMetric.applyContext: VisitContext
       metrics.validAp17FluxMetric: ValidFracColumnMetric
-      metrics.validAp17FluxMetric.vectorKey : 'ap17Flux'
+      metrics.validAp17FluxMetric.vectorKey: 'ap17Flux'
       metrics.validAp17FluxMetric.applyContext: VisitContext
       metrics.validAp25FluxMetric: ValidFracColumnMetric
-      metrics.validAp25FluxMetric.vectorKey : 'ap25Flux'
+      metrics.validAp25FluxMetric.vectorKey: 'ap25Flux'
       metrics.validAp25FluxMetric.applyContext: VisitContext
       metrics.validAp35FluxMetric: ValidFracColumnMetric
-      metrics.validAp35FluxMetric.vectorKey : 'ap35Flux'
+      metrics.validAp35FluxMetric.vectorKey: 'ap35Flux'
       metrics.validAp35FluxMetric.applyContext: VisitContext
       metrics.validAp50FluxMetric: ValidFracColumnMetric
-      metrics.validAp50FluxMetric.vectorKey : 'ap50Flux'
+      metrics.validAp50FluxMetric.vectorKey: 'ap50Flux'
       metrics.validAp50FluxMetric.applyContext: VisitContext
       metrics.validAp70FluxMetric: ValidFracColumnMetric
-      metrics.validAp70FluxMetric.vectorKey : 'ap70Flux'
+      metrics.validAp70FluxMetric.vectorKey: 'ap70Flux'
       metrics.validAp70FluxMetric.applyContext: VisitContext
       metrics.validCalibFluxMetric: ValidFracColumnMetric
-      metrics.validCalibFluxMetric.vectorKey : 'calibFlux'
+      metrics.validCalibFluxMetric.vectorKey: 'calibFlux'
       metrics.validCalibFluxMetric.applyContext: VisitContext
       metrics.validGaussianFluxMetric: ValidFracColumnMetric
-      metrics.validGaussianFluxMetric.vectorKey : 'gaussianFlux'
+      metrics.validGaussianFluxMetric.vectorKey: 'gaussianFlux'
       metrics.validGaussianFluxMetric.applyContext: VisitContext
       python: |
         from lsst.analysis.tools.analysisMetrics import *

--- a/python/lsst/analysis/tools/actions/scalar/scalarActions.py
+++ b/python/lsst/analysis/tools/actions/scalar/scalarActions.py
@@ -179,7 +179,7 @@ class FracInRange(ScalarAction):
     """
 
     vectorKey = Field[str](doc="Name of column")
-    maximum = Field[float](doc="The maximum value", default=np.Inf)
+    maximum = Field[float](doc="The maximum value", default=np.nextafter(np.Inf, 0.0))
     minimum = Field[float](doc="The minimum value", default=np.nextafter(-np.Inf, 0.0))
     percent = Field[bool](doc="Express result as percentage", default=False)
 
@@ -196,17 +196,17 @@ class FracInRange(ScalarAction):
         Returns
         -------
         result : `Scalar`
-            The fraction (or percentage) of rows with values within the specified range.
+            The fraction (or percentage) of rows with values within the
+            specified range.
         """
         mask = self.getMask(**kwargs)
         values = cast(Vector, data[self.vectorKey.format(**kwargs)])[mask]
-        values = values[mask]  # type: ignore
         nvalues = len(values)
         values = values[np.logical_not(np.isnan(values))]
-        maskrange = (values >= self.minimum) & (values < self.maximum)
+        sel_range = (values >= self.minimum) & (values < self.maximum)
         result = cast(
             Scalar,
-            float(len(values[maskrange]) / nvalues),  # type: ignore
+            float(len(values[sel_range]) / nvalues),  # type: ignore
         )
         if self.percent:
             return 100.0 * result
@@ -238,7 +238,6 @@ class FracNan(ScalarAction):
         """
         mask = self.getMask(**kwargs)
         values = cast(Vector, data[self.vectorKey.format(**kwargs)])[mask]
-        values = values[mask]  # type: ignore
         nvalues = len(values)
         values = values[np.isnan(values)]
         result = cast(

--- a/python/lsst/analysis/tools/actions/scalar/scalarActions.py
+++ b/python/lsst/analysis/tools/actions/scalar/scalarActions.py
@@ -215,8 +215,7 @@ class FracInRange(ScalarAction):
 
 
 class FracNan(ScalarAction):
-    """Compute the fraction of vector entries that are NaN.
-    """
+    """Compute the fraction of vector entries that are NaN."""
 
     vectorKey = Field[str](doc="Name of column")
     percent = Field[bool](doc="Express result as percentage", default=False)

--- a/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
@@ -31,10 +31,11 @@ __all__ = (
 )
 
 from lsst.pex.config import Field
-from ..analysisParts.stellarLocus import WPerpCModel, WPerpPSF, XPerpCModel, XPerpPSF, YPerpCModel, YPerpPSF
-from ..interfaces import AnalysisMetric
+
 from ..actions.scalar import FracInRange, FracNan
 from ..actions.vector import LoadVector
+from ..analysisParts.stellarLocus import WPerpCModel, WPerpPSF, XPerpCModel, XPerpPSF, YPerpCModel, YPerpPSF
+from ..interfaces import AnalysisMetric
 
 
 class WPerpPSFMetric(WPerpPSF, AnalysisMetric):
@@ -106,7 +107,8 @@ class ValidFracColumnMetric(AnalysisMetric):
     numerical values (i.e., not NaN), and that fall within the specified
     "reasonable" range for the values.
     """
-    vectorKey = Field[str](doc="Key of column to validate", default='psfFlux')
+
+    vectorKey = Field[str](doc="Key of column to validate", default="psfFlux")
 
     def visitContext(self) -> None:
         self.process.buildActions.loadVector = LoadVector()
@@ -115,8 +117,8 @@ class ValidFracColumnMetric(AnalysisMetric):
 
     def coaddContext(self) -> None:
         self.process.buildActions.loadVector = LoadVector()
-        self.process.buildActions.loadVector.vectorKey = "{band}_"+f"{self.vectorKey}"
-        self._setActions("{band}_"+f"{self.vectorKey}")
+        self.process.buildActions.loadVector.vectorKey = "{band}_" + f"{self.vectorKey}"
+        self._setActions("{band}_" + f"{self.vectorKey}")
 
         # Need to pass a mapping of new names so the default names get the
         # band prepended. Otherwise, each subsequent band's metric will

--- a/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
@@ -35,7 +35,6 @@ from ..analysisParts.stellarLocus import WPerpCModel, WPerpPSF, XPerpCModel, XPe
 from ..interfaces import AnalysisMetric
 from ..actions.scalar import FracInRange, FracNan
 from ..actions.vector import LoadVector
-from ..actions.keyedData import KeyedDataSelectorAction
 
 
 class WPerpPSFMetric(WPerpPSF, AnalysisMetric):
@@ -128,10 +127,13 @@ class ValidFracColumnMetric(AnalysisMetric):
         }
 
     def _setActions(self, name: str) -> None:
+        # The default flux limits of 1e-1 < flux < 1e9 correspond to a
+        # magnitude range of 34 < mag < 9 (i.e., reasonably well-measured)
+        # objects should all be within this range).
         self.process.calculateActions.validFracColumn = FracInRange(
             vectorKey=name,
-            minimum=1.0e-2,
-            maximum=1.0e6,
+            minimum=1.0e-1,
+            maximum=1.0e9,
             percent=True,
         )
         self.process.calculateActions.nanFracColumn = FracNan(
@@ -142,6 +144,7 @@ class ValidFracColumnMetric(AnalysisMetric):
     def setDefaults(self):
         super().setDefaults()
 
-        self.produce.units = {"validFracColumn": "percent",
-                              "nanFracColumn": "percent",
-                             }
+        self.produce.units = {  # type: ignore
+            "validFracColumn": "percent",
+            "nanFracColumn": "percent",
+        }

--- a/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
@@ -30,6 +30,7 @@ __all__ = (
     "ValidFracColumnMetric",
 )
 
+from lsst.pex.config import Field
 from ..analysisParts.stellarLocus import WPerpCModel, WPerpPSF, XPerpCModel, XPerpPSF, YPerpCModel, YPerpPSF
 from ..interfaces import AnalysisMetric
 from ..actions.scalar import FracInRange, FracNan
@@ -106,20 +107,17 @@ class ValidFracColumnMetric(AnalysisMetric):
     numerical values (i.e., not NaN), and that fall within the specified
     "reasonable" range for the values.
     """
-
-    # parameterizedBand: bool = True
-
-    columnKey: str = "psfFlux"
+    vectorKey = Field[str](doc="Key of column to validate", default='psfFlux')
 
     def visitContext(self) -> None:
         self.process.buildActions.loadVector = LoadVector()
-        self.process.buildActions.loadVector.vectorKey = f"{self.columnKey}"
-        self._setActions(f"{self.columnKey}")
+        self.process.buildActions.loadVector.vectorKey = f"{self.vectorKey}"
+        self._setActions(f"{self.vectorKey}")
 
     def coaddContext(self) -> None:
         self.process.buildActions.loadVector = LoadVector()
-        self.process.buildActions.loadVector.vectorKey = "{band}_"+f"{self.columnKey}"
-        self._setActions("{band}_"+f"{self.columnKey}")
+        self.process.buildActions.loadVector.vectorKey = "{band}_"+f"{self.vectorKey}"
+        self._setActions("{band}_"+f"{self.vectorKey}")
 
         # Need to pass a mapping of new names so the default names get the
         # band prepended. Otherwise, each subsequent band's metric will

--- a/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
+++ b/python/lsst/analysis/tools/analysisMetrics/analysisMetrics.py
@@ -32,8 +32,8 @@ __all__ = (
 
 from ..analysisParts.stellarLocus import WPerpCModel, WPerpPSF, XPerpCModel, XPerpPSF, YPerpCModel, YPerpPSF
 from ..interfaces import AnalysisMetric
-from ..actions.scalar import FracInRange
-from ..actions.vector import LoadVector, FlagSelector
+from ..actions.scalar import FracInRange, FracNan
+from ..actions.vector import LoadVector
 from ..actions.keyedData import KeyedDataSelectorAction
 
 
@@ -112,20 +112,21 @@ class ValidFracColumnMetric(AnalysisMetric):
     columnKey: str = "psfFlux"
 
     def visitContext(self) -> None:
-        self.prep.selectors.keyedDataSelector = KeyedDataSelectorAction()
+        self.process.buildActions.loadVector = LoadVector()
+        self.process.buildActions.loadVector.vectorKey = f"{self.columnKey}"
         self._setActions(f"{self.columnKey}")
 
     def coaddContext(self) -> None:
-        self.prep.selectors.keyedDataSelector = KeyedDataSelectorAction()
-        # self.process.buildActions.loadVector = LoadVector()
-        # self.process.buildActions.loadVector.vectorKey = f"{{band}}_{self.columnKey}"
-        self._setActions(f"{{band}}_{self.columnKey}")
+        self.process.buildActions.loadVector = LoadVector()
+        self.process.buildActions.loadVector.vectorKey = "{band}_"+f"{self.columnKey}"
+        self._setActions("{band}_"+f"{self.columnKey}")
 
         # Need to pass a mapping of new names so the default names get the
         # band prepended. Otherwise, each subsequent band's metric will
         # overwrite the current one.
         self.produce.newNames = {
             "validFracColumn": "{band}_validFracColumn",
+            "nanFracColumn": "{band}_nanFracColumn",
         }
 
     def _setActions(self, name: str) -> None:
@@ -135,39 +136,14 @@ class ValidFracColumnMetric(AnalysisMetric):
             maximum=1.0e6,
             percent=True,
         )
+        self.process.calculateActions.nanFracColumn = FracNan(
+            vectorKey=name,
+            percent=True,
+        )
 
     def setDefaults(self):
         super().setDefaults()
 
-        # self.process.buildActions.rangeSelector = RangeSelector()
-        #self.process.buildActions.fracInRangeSelector = FracInRange()
-
-        # select values within range
-        #self.process.buildActions.fracInRangeSelector.vectorKey = "psfFlux"
-        #self.process.buildActions.fracInRangeSelector.minimum = 1e-2
-        #self.process.buildActions.fracInRangeSelector.maximum = 1e6
-
-#        self.process.calculateActions.validFracColumn = FracInRange(
-#            vectorKey="psfFlux",
-#            minimum=1.0e-2,
-#            maximum=1.0e6,
-#            percent=True,
-#        )
-
-        self.produce.units = {"validFracColumn": "percent"}
-
-        # the final name in the qualification is used as a key to insert
-        # the calculation into KeyedData
-        #self.process.filterActions.allInRange = DownselectVector(
-        #    vectorKey=self.process.buildActions.rangeSelector.vectorKey,
-        #    selector=self.process.buildActions.rangeSelector
-        #)
-
-        #self.process.calculateActions.ValidFracColumnMetric = CountAction(vectorKey="allInRange")
-
-        #self.produce.units = {"ValidFracColumnMetric": "ct"}
-
-        #self.produce.units = {  # type: ignore
-        #    "yPerp_psfFlux_sigmaMAD": "mmag",
-        #    "yPerp_psfFlux_median": "mmag",
-        #}
+        self.produce.units = {"validFracColumn": "percent",
+                              "nanFracColumn": "percent",
+                             }


### PR DESCRIPTION
As implemented on this ticket, the `ValidFracColumnMetric` will check what percentage (or fraction) of a column's values are NaNs, and what percentage lie within a specified range of values (for example, a "reasonable" range of flux for object measurements). These are meant for catalog validation purposes. At present, the only metrics implemented are checks on fluxes in SourceTable and ObjectTable. The "valid range" could be applied to any quantity of interest.

I also fixed a docstring in the `CountAction`, and removed an unnecessary (and possibly breaking) **kwargs in the `FracThreshold` action.