### PR TITLE
DM-37452: Port reference line in scatter plot to analysis tools

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Run this command to always ignore formatting commits in `git blame`
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Changes to be compliant with black 23.1.0
+96f2f9c12cdc15ed4ffe3ae0b7886a99d6daa231

--- a/python/lsst/analysis/tools/actions/plot/barPlots.py
+++ b/python/lsst/analysis/tools/actions/plot/barPlots.py
@@ -308,7 +308,6 @@ class BarPlot(PlotAction):
         current_i = 0
 
         for i in x_values:
-
             # Number of repeating values
             n_repeating = x_values.count(i)
             width.append(1.0 / n_repeating)

--- a/python/lsst/analysis/tools/actions/plot/colorColorFitPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/colorColorFitPlot.py
@@ -40,7 +40,6 @@ from .plotUtils import addPlotInfo, mkColormap, perpDistance
 
 
 class ColorColorFitPlot(PlotAction):
-
     xAxisLabel = Field[str](doc="Label to use for the x axis", optional=False)
     yAxisLabel = Field[str](doc="Label to use for the y axis", optional=False)
     magLabel = Field[str](doc="Label to use for the magnitudes used to color code by", optional=False)

--- a/python/lsst/analysis/tools/actions/plot/plotUtils.py
+++ b/python/lsst/analysis/tools/actions/plot/plotUtils.py
@@ -155,7 +155,7 @@ def generateSummaryStatsVisit(cat, colName, visitSummaryTable, plotInfo):
         sumRow = visitSummaryTable["id"] == ccd
         corners = zip(visitSummaryTable["raCorners"][sumRow][0], visitSummaryTable["decCorners"][sumRow][0])
         cornersOut = []
-        for (ra, dec) in corners:
+        for ra, dec in corners:
             corner = SpherePoint(ra, dec, units=degrees)
             cornersOut.append(corner)
 
@@ -455,7 +455,7 @@ def mkColormap(colorNames):
     blues = []
     greens = []
     reds = []
-    for (num, color) in zip(nums, colorNames):
+    for num, color in zip(nums, colorNames):
         r, g, b = colors.colorConverter.to_rgb(color)
         blues.append((num, b, b))
         greens.append((num, g, g))
@@ -502,7 +502,7 @@ def sortAllArrays(arrsToSort, sortArrayIndex=0):
         The list of arrays sorted on array in list index ``sortArrayIndex``.
     """
     ids = extremaSort(arrsToSort[sortArrayIndex])
-    for (i, arr) in enumerate(arrsToSort):
+    for i, arr in enumerate(arrsToSort):
         arrsToSort[i] = arr[ids]
     return arrsToSort
 

--- a/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
+++ b/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
@@ -213,7 +213,6 @@ class ScatterPlotWithTwoHists(PlotAction):
         return base
 
     def __call__(self, data: KeyedData, **kwargs) -> Mapping[str, Figure] | Figure:
-
         self._validateInput(data, **kwargs)
         return self.makePlot(data, **kwargs)
 
@@ -282,11 +281,11 @@ class ScatterPlotWithTwoHists(PlotAction):
 
         # Set default color and line style for the horizontal
         # reference line at 0
-        if 'hlineColor' not in kwargs:
-            kwargs['hlineColor'] = 'black'
+        if "hlineColor" not in kwargs:
+            kwargs["hlineColor"] = "black"
 
-        if 'hlineStyle' not in kwargs:
-            kwargs['hlineStyle'] = (0, (1, 4))
+        if "hlineStyle" not in kwargs:
+            kwargs["hlineStyle"] = (0, (1, 4))
 
         fig = plt.figure(dpi=300)
         gs = gridspec.GridSpec(4, 4)
@@ -410,7 +409,7 @@ class ScatterPlotWithTwoHists(PlotAction):
             )
 
         xMin = None
-        for (j, (xs, ys, highSn, lowSn, color, cmap, highStats, lowStats)) in enumerate(toPlotList):
+        for j, (xs, ys, highSn, lowSn, color, cmap, highStats, lowStats) in enumerate(toPlotList):
             highSn = cast(Vector, highSn)
             lowSn = cast(Vector, lowSn)
             # ensure the columns are actually array
@@ -471,7 +470,7 @@ class ScatterPlotWithTwoHists(PlotAction):
                 threeSigMadVerts = np.zeros((len(xEdgesPlot) * 2, 2))
                 sigMads = np.zeros(len(xEdgesPlot))
 
-                for (i, xEdge) in enumerate(xEdgesPlot):
+                for i, xEdge in enumerate(xEdgesPlot):
                     ids = np.where((xs < xEdge) & (xs > xEdges[i]) & (np.isfinite(ys)))[0]
                     med = np.nanmedian(ys[ids])
                     sigMad = sigmaMad(ys[ids], nan_policy="omit")
@@ -620,7 +619,7 @@ class ScatterPlotWithTwoHists(PlotAction):
                 histIm = None
 
         # Add a horizontal reference line at 0 to the scatter plot
-        ax.axhline(0, color=kwargs['hlineColor'], ls=kwargs['hlineStyle'], alpha=0.7, zorder=-2)
+        ax.axhline(0, color=kwargs["hlineColor"], ls=kwargs["hlineStyle"], alpha=0.7, zorder=-2)
 
         # Set the scatter plot limits
         # TODO: Make this not work by accident
@@ -804,7 +803,7 @@ class ScatterPlotWithTwoHists(PlotAction):
             )
 
         # Add a horizontal reference line at 0 to the side histogram
-        sideHist.axhline(0, color=kwargs['hlineColor'], ls=kwargs['hlineStyle'], alpha=0.7, zorder=-2)
+        sideHist.axhline(0, color=kwargs["hlineColor"], ls=kwargs["hlineStyle"], alpha=0.7, zorder=-2)
 
         sideHist.axes.get_yaxis().set_visible(False)
         sideHist.set_xlabel("Number", fontsize=8)

--- a/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
+++ b/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
@@ -280,6 +280,14 @@ class ScatterPlotWithTwoHists(PlotAction):
             noDataFig = addPlotInfo(noDataFig, plotInfo)
             return noDataFig
 
+        # Set default color and line style for the horizontal
+        # reference line at 0
+        if 'hlineColor' not in kwargs:
+            kwargs['hlineColor'] = 'black'
+
+        if 'hlineStyle' not in kwargs:
+            kwargs['hlineStyle'] = (0, (1, 4))
+
         fig = plt.figure(dpi=300)
         gs = gridspec.GridSpec(4, 4)
 
@@ -537,7 +545,7 @@ class ScatterPlotWithTwoHists(PlotAction):
                 fig.text(xPos, 0.020, statText, bbox=bbox, transform=fig.transFigure, fontsize=6)
 
                 if self.plot2DHist:
-                    histIm = ax.hexbin(xs[inside], ys[inside], gridsize=75, cmap=cmap, mincnt=1, zorder=-2)
+                    histIm = ax.hexbin(xs[inside], ys[inside], gridsize=75, cmap=cmap, mincnt=1, zorder=-3)
 
                 # If there are not many sources being used for the
                 # statistics then plot them individually as just
@@ -610,6 +618,9 @@ class ScatterPlotWithTwoHists(PlotAction):
                 ax.plot(xs, meds - 1.0 * sigMads, color, alpha=0.8)
                 linesForLegend.append(sigMadLine)
                 histIm = None
+
+        # Add a horizontal reference line at 0 to the scatter plot
+        ax.axhline(0, color=kwargs['hlineColor'], ls=kwargs['hlineStyle'], alpha=0.7, zorder=-2)
 
         # Set the scatter plot limits
         # TODO: Make this not work by accident
@@ -791,6 +802,9 @@ class ScatterPlotWithTwoHists(PlotAction):
                 log=True,
                 ls=":",
             )
+
+        # Add a horizontal reference line at 0 to the side histogram
+        sideHist.axhline(0, color=kwargs['hlineColor'], ls=kwargs['hlineStyle'], alpha=0.7, zorder=-2)
 
         sideHist.axes.get_yaxis().set_visible(False)
         sideHist.set_xlabel("Number", fontsize=8)

--- a/python/lsst/analysis/tools/actions/plot/skyPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/skyPlot.py
@@ -40,7 +40,6 @@ from .plotUtils import addPlotInfo, mkColormap, plotProjectionWithBinning, sortA
 
 
 class SkyPlot(PlotAction):
-
     xAxisLabel = Field[str](doc="Label to use for the x axis.", optional=False)
     yAxisLabel = Field[str](doc="Label to use for the y axis.", optional=False)
     zAxisLabel = Field[str](doc="Label to use for the z axis.", optional=False)
@@ -309,7 +308,7 @@ class SkyPlot(PlotAction):
                         path_effects=[pathEffects.withStroke(linewidth=2, foreground="w")],
                     )
 
-        for (i, (xs, ys, colorVals, cmap, label)) in enumerate(toPlotList):
+        for i, (xs, ys, colorVals, cmap, label) in enumerate(toPlotList):
             if not self.plotOutlines or "tract" not in sumStats.keys():
                 minRa = np.min(xs)
                 maxRa = np.max(xs)

--- a/python/lsst/analysis/tools/analysisPlots/diffMatchedPlots.py
+++ b/python/lsst/analysis/tools/analysisPlots/diffMatchedPlots.py
@@ -43,7 +43,7 @@ class MatchedRefCoaddCModelPlot(MatchedRefCoaddPlot):
         self.produce.magLabel = "cModel mag"
 
         # downselect the cModelFlux as well
-        for (prefix, plural) in (("star", "Stars"), ("galaxy", "Galaxies")):
+        for prefix, plural in (("star", "Stars"), ("galaxy", "Galaxies")):
             for suffix in ("", "Err"):
                 setattr(
                     self.process.filterActions,

--- a/python/lsst/analysis/tools/tasks/catalogMatch.py
+++ b/python/lsst/analysis/tools/tasks/catalogMatch.py
@@ -43,7 +43,6 @@ from ..actions.vector import (
 
 
 class AstropyMatchConfig(pexConfig.Config):
-
     maxDistance = pexConfig.Field[float](
         doc="Max distance between matches in arcsec",
         default=1.0,
@@ -113,7 +112,6 @@ class CatalogMatchConnections(
     dimensions=("tract", "skymap"),
     defaultTemplates={"targetCatalog": "objectTable_tract", "refCatalog": "gaia_dr2_20200414"},
 ):
-
     catalog = pipeBase.connectionTypes.Input(
         doc="The tract-wide catalog to make plots from.",
         storageClass="DataFrame",
@@ -147,7 +145,6 @@ class CatalogMatchConnections(
 
 
 class CatalogMatchConfig(pipeBase.PipelineTaskConfig, pipelineConnections=CatalogMatchConnections):
-
     matcher = pexConfig.ConfigurableField[pipeBase.Task](
         target=AstropyMatchTask, doc="Task for matching refCat and SourceCatalog"
     )
@@ -318,7 +315,6 @@ class CatalogMatchVisitConnections(
     dimensions=("visit",),
     defaultTemplates={"targetCatalog": "sourceTable_visit", "refCatalog": "gaia_dr2_20200414"},
 ):
-
     catalog = pipeBase.connectionTypes.Input(
         doc="The visit-wide catalog to make plots from.",
         storageClass="DataFrame",
@@ -421,7 +417,7 @@ class CatalogMatchVisitTask(CatalogMatchTask):
         # Get convex hull around the detectors, then get its center and radius
         corners = []
         for visSum in visitSummaryTable:
-            for (ra, dec) in zip(visSum["raCorners"], visSum["decCorners"]):
+            for ra, dec in zip(visSum["raCorners"], visSum["decCorners"]):
                 corners.append(lsst.geom.SpherePoint(ra, dec, units=lsst.geom.degrees).getVector())
         visitBoundingCircle = lsst.sphgeom.ConvexPolygon.convexHull(corners).getBoundingCircle()
         center = lsst.geom.SpherePoint(visitBoundingCircle.getCenter())

--- a/python/lsst/analysis/tools/tasks/diaObjectTableAssocAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/diaObjectTableAssocAnalysis.py
@@ -16,7 +16,6 @@ class DiaObjectTableAnalysisConnections(
     dimensions=("visit", "band"),
     defaultTemplates={"coaddName": "deep", "fakesType": ""},
 ):
-
     data = ct.Input(
         doc="CcdVisit-based DiaObject table to load from the butler",
         name="{fakesType}{coaddName}Diff_diaObject",

--- a/python/lsst/analysis/tools/tasks/diaSourceTableVisitAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/diaSourceTableVisitAnalysis.py
@@ -12,7 +12,6 @@ class DiaSourceTableCcdVisitAnalysisConnections(
     dimensions=("visit", "band"),
     defaultTemplates={"coaddName": "deep", "fakesType": "fakes_"},
 ):
-
     data = ct.Input(
         doc="CcdVisit-based DiaSource table to load from the butler",
         name="{fakesType}{coaddName}Diff_assocDiaSrc",

--- a/python/lsst/analysis/tools/tasks/objectTableSurveyAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/objectTableSurveyAnalysis.py
@@ -41,7 +41,6 @@ class ObjectTableSurveyAnalysisConnections(
     dimensions=("skymap",),
     defaultTemplates={"input": "deepCoadd"},
 ):
-
     skymap = ct.Input(
         doc="Input definition of geometry/bbox and projection/wcs for warped exposures",
         name="skyMap",

--- a/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
@@ -12,7 +12,6 @@ class SourceTableVisitAnalysisConnections(
     dimensions=("visit", "band"),
     defaultTemplates={"inputName": "sourceTable_visit"},
 ):
-
     data = ct.Input(
         doc="Visit based source table to load from the butler",
         name="sourceTable_visit",


### PR DESCRIPTION
This was previously done in `analysis drp` ([DM-35371](https://github.com/lsst/analysis_drp/pull/49)) and this pull request moves it to `analysis tools`.