### PR TITLE
DM-37330: Add a utility function to compress tract list

### DIFF
--- a/python/lsst/analysis/tools/actions/plot/plotUtils.py
+++ b/python/lsst/analysis/tools/actions/plot/plotUtils.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 __all__ = ("PanelConfig",)
 
-from typing import TYPE_CHECKING, List, Mapping, Tuple
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Tuple
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -596,6 +596,73 @@ def addSummaryPlot(fig, loc, sumStats, label):
     )
 
     return fig
+
+
+def shorten_list(numbers: Iterable[int], *, range_indicator: str = "-", range_separator: str = ",") -> str:
+    """Shorten an iterable of integers.
+
+    Parameters
+    ----------
+    numbers : `~collections.abc.Iterable` [`int`]
+        Any iterable (list, set, tuple, numpy.array) of integers.
+    range_indicator : `str`, optional
+        The string to use to indicate a range of numbers.
+    range_separator : `str`, optional
+        The string to use to separate ranges of numbers.
+
+    Returns
+    -------
+    result : `str`
+        A shortened string representation of the list.
+
+    Examples
+    --------
+    >>> shorten_list([1,2,3,5,6,8])
+    "1-3,5-6,8"
+
+    >>> shorten_list((1,2,3,5,6,8,9,10,11), range_separator=", ")
+    "1-3, 5-6, 8-11"
+
+    >>> shorten_list(range(4), range_indicator="..")
+    "0..3"
+    """
+
+    # Sort the list in ascending order.
+    numbers = sorted(numbers)
+
+    if not numbers:  # empty container
+        return ""
+
+    # Initialize an empty list to hold the results to be returned.
+    result = []
+
+    # Initialize variables to track the current start and end of a list.
+    start = 0
+    end = 0  # initialize to 0 to handle single element lists.
+
+    # Iterate through the sorted list of numbers
+    for end in range(1, len(numbers)):
+        # If the current number is the same or consecutive to the previous
+        # number, skip to the next iteration.
+        if numbers[end] > numbers[end - 1] + 1:  # > is used to handle duplicates, if any.
+            # If the current number is not consecutive to the previous number,
+            # add the current range to the result and reset the start to end.
+            if start == end - 1:
+                result.append(str(numbers[start]))
+            else:
+                result.append(range_indicator.join((str(numbers[start]), str(numbers[end - 1]))))
+
+            # Update start.
+            start = end
+
+    # Add the final range to the result.
+    if start == end:
+        result.append(str(numbers[start]))
+    else:
+        result.append(range_indicator.join((str(numbers[start]), str(numbers[end]))))
+
+    # Return the shortened string representation.
+    return range_separator.join(result)
 
 
 class PanelConfig(Config):

--- a/python/lsst/analysis/tools/tasks/objectTableSurveyAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/objectTableSurveyAnalysis.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 from lsst.pipe.base import connectionTypes as ct
 
+from ..actions.plot.plotUtils import shorten_list
 from ..interfaces import KeyedData
 from .base import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 
@@ -76,17 +77,17 @@ class ObjectTableSurveyAnalysisTask(AnalysisPipelineTask):
         if inputs is None:
             tableName = ""
             run = ""
-            tracts = ""
+            tracts = []
         else:
             tableName = inputs[connectionName][0].ref.datasetType.name
             run = inputs[connectionName][0].ref.run
-            tracts = str([data.ref.dataId["tract"] for data in inputs[connectionName]])
+            tracts = [data.ref.dataId["tract"] for data in inputs[connectionName]]
 
         # Initialize the plot info dictionary
         plotInfo = {
             "tableName": tableName,
             "run": run,
-            "tract": tracts,
+            "tract": shorten_list(tracts),
         }
 
         self._populatePlotInfoWithDataId(plotInfo, dataId)

--- a/tests/test_plotUtils.py
+++ b/tests/test_plotUtils.py
@@ -21,7 +21,46 @@
 import unittest
 
 import lsst.utils.tests
-from lsst.analysis.tools.actions.plot.plotUtils import shorten_list
+import numpy as np
+from lsst.analysis.tools.actions.plot.plotUtils import perpDistance, shorten_list, stellarLocusFit
+
+
+class FitTest(lsst.utils.tests.TestCase):
+    """Test to see if the fitting and distance calculations are working."""
+
+    def testFitLine(self):
+        """Make a known array of points for x and y and then test that
+        the derived fit parameters are as expected."""
+
+        xs = np.arange(1, 10)
+        ys = np.arange(1, 10)
+
+        # Define an initial fit box that encompasses the points
+        testParams = {"xMin": 0, "xMax": 11, "yMin": 0, "yMax": 11, "mHW": 1, "bHW": 0}
+        paramsOut = stellarLocusFit(xs, ys, testParams)
+
+        # stellarLocusFit performs two iterations of fitting and also
+        # calculates the perpendicular gradient to the fit line and
+        # the points of intersection between the box and the fit
+        # line. Test that these are returning what is expected.
+        self.assertFloatsAlmostEqual(paramsOut["mODR"], 1.0)
+        self.assertFloatsAlmostEqual(paramsOut["mODR2"], 1.0)
+        self.assertFloatsAlmostEqual(paramsOut["bODR"], 0.0)
+        self.assertFloatsAlmostEqual(paramsOut["bODR2"], 0.0)
+        self.assertFloatsAlmostEqual(paramsOut["bPerpMin"], 0.0)
+        self.assertFloatsAlmostEqual(paramsOut["bPerpMax"], 22.0)
+
+    def testPerpDistance(self):
+        """Test the calculation of the perpendicular distance."""
+
+        p1 = np.array([1, 1])
+        p2 = np.array([2, 2])
+        testPoints = np.array([[1, 2], [1.5, 1.5], [2, 1]])
+        # perpDistance uses two points, p1 and p2, to define a line
+        # then calculates the perpendicular distance of the testPoints
+        # to this line
+        dists = perpDistance(p1, p2, testPoints)
+        self.assertFloatsAlmostEqual(np.array([1.0 / np.sqrt(2), 0.0, -1.0 / np.sqrt(2)]), np.array(dists))
 
 
 class ShortListTestCase(lsst.utils.tests.TestCase):

--- a/tests/test_plotUtils.py
+++ b/tests/test_plotUtils.py
@@ -1,0 +1,76 @@
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+import lsst.utils.tests
+from lsst.analysis.tools.actions.plot.plotUtils import shorten_list
+
+
+class ShortListTestCase(lsst.utils.tests.TestCase):
+    """Test to see if the shorten_list function works as it should."""
+
+    def test_shorten_list(self):
+        self.assertEqual(shorten_list([]), "")  # empty container
+        self.assertEqual(shorten_list([5]), "5")  # single element
+        self.assertEqual(shorten_list([5, 6]), "5-6")  # 2 contigous elements
+        self.assertEqual(shorten_list([5, 7]), "5,7")  # 2 non-contiguous elements
+        self.assertEqual(shorten_list([-7, -6, -5]), "-7--5")  # 3 contiguous elements
+        self.assertEqual(shorten_list([5, 7, 9]), "5,7,9")  # 3 non-contiguous elements
+        self.assertEqual(shorten_list([5, 6, 8]), "5-6,8")  # 3 mixed elements
+
+        # Test for different data types
+        self.assertEqual(shorten_list({1, 2, 3, 5, 7, 8, 9, 10, 13}), "1-3,5,7-10,13")  # test for a set
+        self.assertEqual(
+            shorten_list((1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18)), "1-3,5-13,15-18"
+        )  # test for a tuple
+        self.assertEqual(shorten_list(range(100)), "0-99")  # test for an itertor
+        self.assertEqual(shorten_list(np.arange(100, dtype=int)), "0-99")  # test for a numpy array
+
+        # Test the RC2/DC2 tract list explicitly.
+        self.assertEqual(shorten_list([9615, 9813, 9697]), "9615,9697,9813")
+        self.assertEqual(shorten_list([3828, 3829]), "3828-3829")
+
+        # Test the keyword-only arguments.
+        self.assertEqual(shorten_list([1, 2, 3, 4, 7, 8, 9], range_indicator=".."), "1..4,7..9")
+        self.assertEqual(shorten_list([1, 2, 3, 4, 7, 8, 9], range_separator="^"), "1-4^7-9")
+        self.assertEqual(
+            shorten_list([1, 2, 3, 4, 7, 8, 9], range_indicator=":", range_separator=";"), "1:4;7:9"
+        )
+
+        # Test that those are keyword only.
+        with self.assertRaises(TypeError):
+            shorten_list([1, 2, 3, 4, 7, 8, 9], "..", "^")
+        with self.assertRaises(TypeError):
+            shorten_list([1, 2, 3, 4, 7, 8, 9], "..", range_separator="^")
+        with self.assertRaises(TypeError):
+            shorten_list([1, 2, 3, 4, 7, 8, 9], "!", range_indicator="..")
+
+        # Test that it sorts the container.
+        self.assertEqual(shorten_list([6, 3, 1, 2]), "1-3,6")
+
+        # Repeated numbers are not expected. Test that the function can
+        # nevertheless handle it.
+        self.assertEqual(shorten_list([1, 2, 2, 3, 3, 3, 5, 7, 8, 7]), "1-3,5,7-8")
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR adds a utility function to `plotUtils` and unit tests for it. It also copies the unit tests for other `plotUtils` functions from `analysis_drp`.