### PR TITLE
DM-36649 Update import paths to pex_config

### DIFF
--- a/python/lsst/analysis/tools/__init__.py
+++ b/python/lsst/analysis/tools/__init__.py
@@ -29,10 +29,10 @@ post-process. Creating a new `AnalysisTool` is the process of choosing (though
 configuration) what `AnalysisAction` will run for each of those stages.
 
 `AnalysisTool`\ s and `AnalysisAction`\ s are subclasses of
-`~lsst.pipe.tasks.configurableActions.ConfigurableAction`\ s. These objects are
+`~lsst.pex.config.configurableActions.ConfigurableAction`\ s. These objects are
 special types that are configured _prior_ to any code execution, and behave as
 functions at runtime. The configuration state of a
-`~lsst.pipe.tasks.configurableActions.ConfigurableAction` is saved separately
+`~lsst.pex.config.configurableActions.ConfigurableAction` is saved separately
 from the object itself, which allows
 """
 

--- a/python/lsst/analysis/tools/actions/keyedData/keyedDataActions.py
+++ b/python/lsst/analysis/tools/actions/keyedData/keyedDataActions.py
@@ -31,8 +31,8 @@ from typing import Optional, cast
 
 import numpy as np
 from lsst.pex.config import Field
+from lsst.pex.config.configurableActions import ConfigurableActionField, ConfigurableActionStructField
 from lsst.pex.config.listField import ListField
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField, ConfigurableActionStructField
 
 from ...interfaces import (
     KeyedData,

--- a/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
+++ b/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
@@ -29,8 +29,8 @@ from typing import Mapping, NamedTuple, Optional, cast
 import matplotlib.pyplot as plt
 import numpy as np
 from lsst.pex.config import Field
+from lsst.pex.config.configurableActions import ConfigurableActionField
 from lsst.pex.config.listField import ListField
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField
 from lsst.skymap import BaseSkyMap
 from matplotlib import gridspec
 from matplotlib.axes import Axes

--- a/python/lsst/analysis/tools/actions/vector/calcBinnedStats.py
+++ b/python/lsst/analysis/tools/actions/vector/calcBinnedStats.py
@@ -27,7 +27,7 @@ from typing import cast
 
 import numpy as np
 from lsst.pex.config import Field
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField
+from lsst.pex.config.configurableActions import ConfigurableActionField
 
 from ...interfaces import KeyedData, KeyedDataAction, KeyedDataSchema, Scalar, Vector
 from ..keyedData.summaryStatistics import SummaryStatisticAction

--- a/python/lsst/analysis/tools/actions/vector/ellipticity.py
+++ b/python/lsst/analysis/tools/actions/vector/ellipticity.py
@@ -29,7 +29,7 @@ __all__ = (
 
 import numpy as np
 from lsst.pex.config import ChoiceField, Field, FieldValidationError
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField
+from lsst.pex.config.configurableActions import ConfigurableActionField
 
 from ...interfaces import KeyedData, KeyedDataSchema, Vector, VectorAction
 

--- a/python/lsst/analysis/tools/actions/vector/vectorActions.py
+++ b/python/lsst/analysis/tools/actions/vector/vectorActions.py
@@ -44,7 +44,7 @@ import numpy as np
 import pandas as pd
 from astropy import units as u
 from lsst.pex.config import DictField, Field
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField, ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionField, ConfigurableActionStructField
 
 from ...interfaces import KeyedData, KeyedDataSchema, Vector, VectorAction
 from .selectors import VectorSelector

--- a/python/lsst/analysis/tools/analysisParts/base.py
+++ b/python/lsst/analysis/tools/analysisParts/base.py
@@ -26,8 +26,8 @@ from collections import abc
 from typing import Mapping
 
 import astropy.units as apu
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.pex.config.dictField import DictField
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
 from lsst.verify import Measurement
 
 from ..actions.keyedData import KeyedDataSelectorAction

--- a/python/lsst/analysis/tools/analysisParts/shapeSizeFractional.py
+++ b/python/lsst/analysis/tools/analysisParts/shapeSizeFractional.py
@@ -27,7 +27,7 @@ __all__ = (
 )
 
 from lsst.pex.config import Field
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField
+from lsst.pex.config.configurableActions import ConfigurableActionField
 
 from ..actions.keyedData import KeyedScalars
 from ..actions.plot.scatterplotWithTwoHists import ScatterPlotStatsAction

--- a/python/lsst/analysis/tools/contexts/_baseContext.py
+++ b/python/lsst/analysis/tools/contexts/_baseContext.py
@@ -29,7 +29,7 @@ __all__ = ("ContextMeta", "Context", "ContextType", "ContextApplier")
 from functools import partial, update_wrapper
 from typing import TYPE_CHECKING, Callable, Iterable, Union, cast, overload
 
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStruct
+from lsst.pex.config.configurableActions import ConfigurableActionStruct
 
 if TYPE_CHECKING:
     from ..interfaces import AnalysisAction

--- a/python/lsst/analysis/tools/interfaces.py
+++ b/python/lsst/analysis/tools/interfaces.py
@@ -46,7 +46,7 @@ from typing import Any, Iterable, Mapping, MutableMapping, Tuple, Type
 
 import numpy as np
 from lsst.pex.config import Field
-from lsst.pipe.tasks.configurableActions import ConfigurableAction, ConfigurableActionField
+from lsst.pex.config.configurableActions import ConfigurableAction, ConfigurableActionField
 from lsst.verify import Measurement
 from matplotlib.figure import Figure
 from numpy.typing import NDArray

--- a/python/lsst/analysis/tools/tasks/base.py
+++ b/python/lsst/analysis/tools/tasks/base.py
@@ -41,11 +41,11 @@ if TYPE_CHECKING:
 
 from lsst.daf.butler import DataCoordinate
 from lsst.pex.config import ListField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.pipe.base import PipelineTask, PipelineTaskConfig, PipelineTaskConnections, Struct
 from lsst.pipe.base import connectionTypes as ct
 from lsst.pipe.base.butlerQuantumContext import ButlerQuantumContext
 from lsst.pipe.base.connections import InputQuantizedConnection, OutputQuantizedConnection
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
 
 from ..analysisMetrics.metricMeasurementBundle import MetricMeasurementBundle
 from ..interfaces import AnalysisMetric, AnalysisPlot, KeyedData

--- a/python/lsst/analysis/tools/tasks/catalogMatch.py
+++ b/python/lsst/analysis/tools/tasks/catalogMatch.py
@@ -30,7 +30,7 @@ import pandas as pd
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from lsst.meas.algorithms import ReferenceObjectLoader
-from lsst.pipe.tasks.configurableActions import ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionStructField
 from lsst.skymap import BaseSkyMap
 
 from ..actions.vector import (

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -39,7 +39,7 @@ from lsst.analysis.tools import (
 from lsst.analysis.tools.actions.scalar import MeanAction, MedianAction
 from lsst.analysis.tools.contexts import Context
 from lsst.pex.config import Field
-from lsst.pipe.tasks.configurableActions import ConfigurableActionField, ConfigurableActionStructField
+from lsst.pex.config.configurableActions import ConfigurableActionField, ConfigurableActionStructField
 
 
 class MedianContext(Context):

--- a/ups/analysis_tools.table
+++ b/ups/analysis_tools.table
@@ -10,7 +10,6 @@ setupRequired(geom)
 setupRequired(meas_algorithms)
 setupRequired(pex_config)
 setupRequired(pipe_base)
-setupRequired(pipe_tasks)
 setupRequired(skymap)
 
 # The following is boilerplate for all packages.


### PR DESCRIPTION
Configurable Actions have moved to pex_config, update all the imports to reflect the new location.