### PR TITLE
DM-38974: Move photometric repeatability metrics from faro to analysis_tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,19 @@ repos:
     rev: v4.4.0
     hooks:
       - id: check-yaml
+        args:
+          - "--unsafe"
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: "python3.10"
+        language_version: python3.10
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+        language_version: python3.11
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -28,6 +28,13 @@ tasks:
     config:
       bands: ['g', 'r', 'i', 'z', 'y']
       connections.outputName: matchedVisitExtended
+      atools.modelPhotRepGalSn5to10: PhotometricRepeatability
+      atools.modelPhotRepGalSn5to10.fluxType: cModelFlux
+      atools.modelPhotRepGalSn5to10.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
+      atools.modelPhotRepGalSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 5
+      atools.modelPhotRepGalSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 10
+      atools.modelPhotRepGalSn5to10.produce.plot: NoPlot
+
       atools.modelPhotRepGalSn10to20: PhotometricRepeatability
       atools.modelPhotRepGalSn10to20.fluxType: cModelFlux
       atools.modelPhotRepGalSn10to20.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
@@ -40,7 +47,58 @@ tasks:
       atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
       atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
       atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
-      # atools.modelPhotRepGalSn20to40.produce.plot: NoPlot
+      atools.modelPhotRepGalSn20to40.produce.plot: NoPlot
+
+      atools.modelPhotRepGalSn40to80: PhotometricRepeatability
+      atools.modelPhotRepGalSn40to80.fluxType: cModelFlux
+      atools.modelPhotRepGalSn40to80.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
+      atools.modelPhotRepGalSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 40
+      atools.modelPhotRepGalSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 80
+      atools.modelPhotRepGalSn40to80.produce.plot: NoPlot
+
+      atools.modelPhotRepStarSn5to10: PhotometricRepeatability
+      atools.modelPhotRepStarSn5to10.fluxType: cModelFlux
+      atools.modelPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 5
+      atools.modelPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 10
+      atools.modelPhotRepStarSn5to10.produce.plot: NoPlot
+
+      atools.modelPhotRepStarSn10to20: PhotometricRepeatability
+      atools.modelPhotRepStarSn10to20.fluxType: cModelFlux
+      atools.modelPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 10
+      atools.modelPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 20
+      atools.modelPhotRepStarSn10to20.produce.plot: NoPlot
+
+      atools.modelPhotRepStarSn20to40: PhotometricRepeatability
+      atools.modelPhotRepStarSn20to40.fluxType: cModelFlux
+      atools.modelPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
+      atools.modelPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
+      atools.modelPhotRepStarSn20to40.produce.plot: NoPlot
+
+      atools.modelPhotRepStarSn40to80: PhotometricRepeatability
+      atools.modelPhotRepStarSn40to80.fluxType: cModelFlux
+      atools.modelPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 40
+      atools.modelPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 80
+      atools.modelPhotRepStarSn40to80.produce.plot: NoPlot
+
+      atools.psfPhotRepStarSn5to10: PhotometricRepeatability
+      atools.psfPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 5
+      atools.psfPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 10
+      atools.psfPhotRepStarSn5to10.produce.plot: NoPlot
+
+      atools.psfPhotRepStarSn10to20: PhotometricRepeatability
+      atools.psfPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 10
+      atools.psfPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 20
+      atools.psfPhotRepStarSn10to20.produce.plot: NoPlot
+
+      atools.psfPhotRepStarSn20to40: PhotometricRepeatability
+      atools.psfPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
+      atools.psfPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
+      atools.psfPhotRepStarSn20to40.produce.plot: NoPlot
+
+      atools.psfPhotRepStarSn40to80: PhotometricRepeatability
+      atools.psfPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 40
+      atools.psfPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 80
+      atools.psfPhotRepStarSn40to80.produce.plot: NoPlot
       python: |
         from lsst.analysis.tools.atools import *
         from lsst.analysis.tools.interfaces import *

--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -5,7 +5,7 @@ tasks:
     class: lsst.analysis.tools.tasks.AssociatedSourcesTractAnalysisTask
     config:
       connections.outputName: matchedVisitCore
-      atools.PhotometricRepeatabilityMetric: PhotometricRepeatability
+      atools.stellarPhotometricRepeatabilityMetric: StellarPhotometricRepeatability
       atools.stellarPhotometricResiduals: StellarPhotometricResidualsFocalPlane
       atools.stellarAstrometricResidualsRA: StellarAstrometricResidualsRAFocalPlanePlot
       atools.stellarAstrometricResidualsDec: StellarAstrometricResidualsDecFocalPlanePlot
@@ -27,46 +27,46 @@ tasks:
     class: lsst.analysis.tools.tasks.AssociatedSourcesTractAnalysisTask
     config:
       connections.outputName: matchedVisitExtended
-      atools.modelPhotRepStarSn5to10: PhotometricRepeatability
+      atools.modelPhotRepStarSn5to10: StellarPhotometricRepeatability
       atools.modelPhotRepStarSn5to10.fluxType: gaussianFlux
       atools.modelPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 5
       atools.modelPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 10
       atools.modelPhotRepStarSn5to10.produce.plot: NoPlot
 
-      atools.modelPhotRepStarSn10to20: PhotometricRepeatability
+      atools.modelPhotRepStarSn10to20: StellarPhotometricRepeatability
       atools.modelPhotRepStarSn10to20.fluxType: gaussianFlux
       atools.modelPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 10
       atools.modelPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 20
       atools.modelPhotRepStarSn10to20.produce.plot: NoPlot
 
-      atools.modelPhotRepStarSn20to40: PhotometricRepeatability
+      atools.modelPhotRepStarSn20to40: StellarPhotometricRepeatability
       atools.modelPhotRepStarSn20to40.fluxType: gaussianFlux
       atools.modelPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
       atools.modelPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
       atools.modelPhotRepStarSn20to40.produce.plot: NoPlot
 
-      atools.modelPhotRepStarSn40to80: PhotometricRepeatability
+      atools.modelPhotRepStarSn40to80: StellarPhotometricRepeatability
       atools.modelPhotRepStarSn40to80.fluxType: gaussianFlux
       atools.modelPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 40
       atools.modelPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 80
       atools.modelPhotRepStarSn40to80.produce.plot: NoPlot
 
-      atools.psfPhotRepStarSn5to10: PhotometricRepeatability
+      atools.psfPhotRepStarSn5to10: StellarPhotometricRepeatability
       atools.psfPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 5
       atools.psfPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 10
       atools.psfPhotRepStarSn5to10.produce.plot: NoPlot
 
-      atools.psfPhotRepStarSn10to20: PhotometricRepeatability
+      atools.psfPhotRepStarSn10to20: StellarPhotometricRepeatability
       atools.psfPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 10
       atools.psfPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 20
       atools.psfPhotRepStarSn10to20.produce.plot: NoPlot
 
-      atools.psfPhotRepStarSn20to40: PhotometricRepeatability
+      atools.psfPhotRepStarSn20to40: StellarPhotometricRepeatability
       atools.psfPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
       atools.psfPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
       atools.psfPhotRepStarSn20to40.produce.plot: NoPlot
 
-      atools.psfPhotRepStarSn40to80: PhotometricRepeatability
+      atools.psfPhotRepStarSn40to80: StellarPhotometricRepeatability
       atools.psfPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 40
       atools.psfPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 80
       atools.psfPhotRepStarSn40to80.produce.plot: NoPlot

--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -5,7 +5,7 @@ tasks:
     class: lsst.analysis.tools.tasks.AssociatedSourcesTractAnalysisTask
     config:
       connections.outputName: matchedVisitCore
-      atools.stellarPhotometricRepeatabilityMetric: StellarPhotometricRepeatability
+      atools.stellarPhotometricRepeatability: StellarPhotometricRepeatability
       atools.stellarPhotometricResiduals: StellarPhotometricResidualsFocalPlane
       atools.stellarAstrometricResidualsRA: StellarAstrometricResidualsRAFocalPlanePlot
       atools.stellarAstrometricResidualsDec: StellarAstrometricResidualsDecFocalPlanePlot

--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -5,7 +5,7 @@ tasks:
     class: lsst.analysis.tools.tasks.AssociatedSourcesTractAnalysisTask
     config:
       connections.outputName: matchedVisitCore
-      atools.stellarPhotometricRepeatability: StellarPhotometricRepeatability
+      atools.PhotometricRepeatabilityMetric: PhotometricRepeatability
       atools.stellarPhotometricResiduals: StellarPhotometricResidualsFocalPlane
       atools.stellarAstrometricResidualsRA: StellarAstrometricResidualsRAFocalPlanePlot
       atools.stellarAstrometricResidualsDec: StellarAstrometricResidualsDecFocalPlanePlot
@@ -23,3 +23,24 @@ tasks:
       atools.stellarAstrometricRepeatability3.process.calculateActions.rms.threshAD: 30
       python: |
         from lsst.analysis.tools.atools import *
+  analyzeMatchedVisitExtended:
+    class: lsst.analysis.tools.tasks.AssociatedSourcesTractAnalysisTask
+    config:
+      bands: ['g', 'r', 'i', 'z', 'y']
+      connections.outputName: matchedVisitExtended
+      atools.modelPhotRepGalSn10to20: PhotometricRepeatability
+      atools.modelPhotRepGalSn10to20.fluxType: cModelFlux
+      atools.modelPhotRepGalSn10to20.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
+      atools.modelPhotRepGalSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 10
+      atools.modelPhotRepGalSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 20
+      atools.modelPhotRepGalSn10to20.produce.plot: NoPlot
+
+      atools.modelPhotRepGalSn20to40: PhotometricRepeatability
+      atools.modelPhotRepGalSn20to40.fluxType: cModelFlux
+      atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
+      atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
+      atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
+      # atools.modelPhotRepGalSn20to40.produce.plot: NoPlot
+      python: |
+        from lsst.analysis.tools.atools import *
+        from lsst.analysis.tools.interfaces import *

--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -26,56 +26,27 @@ tasks:
   analyzeMatchedVisitExtended:
     class: lsst.analysis.tools.tasks.AssociatedSourcesTractAnalysisTask
     config:
-      bands: ['g', 'r', 'i', 'z', 'y']
       connections.outputName: matchedVisitExtended
-      atools.modelPhotRepGalSn5to10: PhotometricRepeatability
-      atools.modelPhotRepGalSn5to10.fluxType: cModelFlux
-      atools.modelPhotRepGalSn5to10.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
-      atools.modelPhotRepGalSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 5
-      atools.modelPhotRepGalSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 10
-      atools.modelPhotRepGalSn5to10.produce.plot: NoPlot
-
-      atools.modelPhotRepGalSn10to20: PhotometricRepeatability
-      atools.modelPhotRepGalSn10to20.fluxType: cModelFlux
-      atools.modelPhotRepGalSn10to20.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
-      atools.modelPhotRepGalSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 10
-      atools.modelPhotRepGalSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 20
-      atools.modelPhotRepGalSn10to20.produce.plot: NoPlot
-
-      atools.modelPhotRepGalSn20to40: PhotometricRepeatability
-      atools.modelPhotRepGalSn20to40.fluxType: cModelFlux
-      atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
-      atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
-      atools.modelPhotRepGalSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
-      atools.modelPhotRepGalSn20to40.produce.plot: NoPlot
-
-      atools.modelPhotRepGalSn40to80: PhotometricRepeatability
-      atools.modelPhotRepGalSn40to80.fluxType: cModelFlux
-      atools.modelPhotRepGalSn40to80.process.filterActions.perGroupStdevFiltered.selectors.extendedness.op: gt
-      atools.modelPhotRepGalSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 40
-      atools.modelPhotRepGalSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 80
-      atools.modelPhotRepGalSn40to80.produce.plot: NoPlot
-
       atools.modelPhotRepStarSn5to10: PhotometricRepeatability
-      atools.modelPhotRepStarSn5to10.fluxType: cModelFlux
+      atools.modelPhotRepStarSn5to10.fluxType: gaussianFlux
       atools.modelPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 5
       atools.modelPhotRepStarSn5to10.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 10
       atools.modelPhotRepStarSn5to10.produce.plot: NoPlot
 
       atools.modelPhotRepStarSn10to20: PhotometricRepeatability
-      atools.modelPhotRepStarSn10to20.fluxType: cModelFlux
+      atools.modelPhotRepStarSn10to20.fluxType: gaussianFlux
       atools.modelPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 10
       atools.modelPhotRepStarSn10to20.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 20
       atools.modelPhotRepStarSn10to20.produce.plot: NoPlot
 
       atools.modelPhotRepStarSn20to40: PhotometricRepeatability
-      atools.modelPhotRepStarSn20to40.fluxType: cModelFlux
+      atools.modelPhotRepStarSn20to40.fluxType: gaussianFlux
       atools.modelPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 20
       atools.modelPhotRepStarSn20to40.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 40
       atools.modelPhotRepStarSn20to40.produce.plot: NoPlot
 
       atools.modelPhotRepStarSn40to80: PhotometricRepeatability
-      atools.modelPhotRepStarSn40to80.fluxType: cModelFlux
+      atools.modelPhotRepStarSn40to80.fluxType: gaussianFlux
       atools.modelPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.minimum: 40
       atools.modelPhotRepStarSn40to80.process.filterActions.perGroupStdevFiltered.selectors.sn.maximum: 80
       atools.modelPhotRepStarSn40to80.produce.plot: NoPlot

--- a/python/lsst/analysis/tools/actions/vector/selectors.py
+++ b/python/lsst/analysis/tools/actions/vector/selectors.py
@@ -210,7 +210,6 @@ class RangeSelector(VectorAction):
         mask = (values >= self.minimum) & (values < self.maximum)
 
         return cast(Vector, mask)
-        # return np.array(mask)
 
 
 class SnSelector(SelectorBase):

--- a/python/lsst/analysis/tools/actions/vector/selectors.py
+++ b/python/lsst/analysis/tools/actions/vector/selectors.py
@@ -187,12 +187,12 @@ class VisitPlotFlagSelector(FlagSelector):
 class RangeSelector(VectorAction):
     """Selects rows within a range, inclusive of min/exclusive of max."""
 
-    key = Field[str](doc="Key to select from data")
+    vectorKey = Field[str](doc="Key to select from data")
     maximum = Field[float](doc="The maximum value", default=np.Inf)
     minimum = Field[float](doc="The minimum value", default=np.nextafter(-np.Inf, 0.0))
 
     def getInputSchema(self) -> KeyedDataSchema:
-        yield self.key, Vector
+        yield self.vectorKey, Vector
 
     def __call__(self, data: KeyedData, **kwargs) -> Vector:
         """Return a mask of rows with values within the specified range.
@@ -206,10 +206,11 @@ class RangeSelector(VectorAction):
         result : `Vector`
             A mask of the rows with values within the specified range.
         """
-        values = cast(Vector, data[self.key])
+        values = cast(Vector, data[self.vectorKey])
         mask = (values >= self.minimum) & (values < self.maximum)
 
-        return np.array(mask)
+        return cast(Vector, mask)
+        # return np.array(mask)
 
 
 class SnSelector(SelectorBase):

--- a/python/lsst/analysis/tools/atools/astrometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/astrometricRepeatability.py
@@ -231,7 +231,9 @@ class AstrometricRelativeRepeatability(AnalysisTool):
 
         # Select only sources with magnitude between 17 and 21.5
         self.process.filterActions.coord_ra = DownselectVector(vectorKey="coord_ra")
-        self.process.filterActions.coord_ra.selector = RangeSelector(key="mags", minimum=17, maximum=21.5)
+        self.process.filterActions.coord_ra.selector = RangeSelector(
+            vectorKey="mags", minimum=17, maximum=21.5
+        )
         self.process.filterActions.coord_dec = DownselectVector(
             vectorKey="coord_dec", selector=self.process.filterActions.coord_ra.selector
         )

--- a/python/lsst/analysis/tools/atools/diffMatched.py
+++ b/python/lsst/analysis/tools/atools/diffMatched.py
@@ -146,7 +146,7 @@ class MatchedRefCoaddDiffMetric(MatchedRefCoaddDiffTool):
             for minimum in range(self._mag_low_min, self._mag_low_max + 1):
                 action = getattr(self.process.calculateActions, f"{name}{minimum}")
                 action.selector_range = RangeSelector(
-                    key=x_key,
+                    vectorKey=x_key,
                     minimum=minimum,
                     maximum=minimum + self._mag_interval,
                 )
@@ -180,7 +180,7 @@ class MatchedRefCoaddDiffMetric(MatchedRefCoaddDiffTool):
                     CalcBinnedStatsAction(
                         key_vector=key,
                         selector_range=RangeSelector(
-                            key=key,
+                            vectorKey=key,
                             minimum=minimum,
                             maximum=minimum + self._mag_interval,
                         ),

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -20,10 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = (
-    "StellarPhotometricRepeatability",
-    "StellarPhotometricResidualsFocalPlane",
-)
+__all__ = ("PhotometricRepeatability", "StellarPhotometricResidualsFocalPlane")
 
 from lsst.pex.config import Field
 
@@ -38,14 +35,15 @@ from ..actions.vector import (
     PerGroupStatistic,
     ResidualWithPerGroupStatistic,
     SnSelector,
+    RangeSelector,
     ThresholdSelector,
 )
 from ..interfaces import AnalysisTool
 
 
-class StellarPhotometricRepeatability(AnalysisTool):
+class PhotometricRepeatability(AnalysisTool):
     """Compute photometric repeatability from multiple measurements of a set of
-    stars. First, a set of per-source quality criteria are applied. Second,
+    sources. First, a set of per-source quality criteria are applied. Second,
     the individual source measurements are grouped together by object index
     and per-group quantities are computed (e.g., a representative S/N for the
     group based on the median of associated per-source measurements). Third,
@@ -93,10 +91,9 @@ class StellarPhotometricRepeatability(AnalysisTool):
             op="ge",
             threshold=3,
         )
-        self.process.filterActions.perGroupStdevFiltered.selectors.sn = ThresholdSelector(
+        self.process.filterActions.perGroupStdevFiltered.selectors.sn = RangeSelector(
             vectorKey="perGroupSn",
-            op="ge",
-            threshold=200,
+            minimum=200,
         )
         self.process.filterActions.perGroupStdevFiltered.selectors.extendedness = ThresholdSelector(
             vectorKey="perGroupExtendedness",
@@ -113,6 +110,8 @@ class StellarPhotometricRepeatability(AnalysisTool):
             percent=True,
         )
         self.process.calculateActions.photRepeatNsources = CountAction(vectorKey="perGroupStdevFiltered")
+
+        # import pdb; pdb.set_trace()
 
         self.produce.plot = HistPlot()
 

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -33,9 +33,9 @@ from ..actions.vector import (
     LoadVector,
     MultiCriteriaDownselectVector,
     PerGroupStatistic,
+    RangeSelector,
     ResidualWithPerGroupStatistic,
     SnSelector,
-    RangeSelector,
     ThresholdSelector,
 )
 from ..interfaces import AnalysisTool

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -111,8 +111,6 @@ class PhotometricRepeatability(AnalysisTool):
         )
         self.process.calculateActions.photRepeatNsources = CountAction(vectorKey="perGroupStdevFiltered")
 
-        # import pdb; pdb.set_trace()
-
         self.produce.plot = HistPlot()
 
         self.produce.plot.panels["panel_rms"] = HistPanel()

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -20,7 +20,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = ("PhotometricRepeatability", "StellarPhotometricResidualsFocalPlane")
+__all__ = (
+    
+    "StellarPhotometricRepeatability", 
+    "StellarPhotometricResidualsFocalPlane",
+)
 
 from lsst.pex.config import Field
 
@@ -41,9 +45,9 @@ from ..actions.vector import (
 from ..interfaces import AnalysisTool
 
 
-class PhotometricRepeatability(AnalysisTool):
+class StellarPhotometricRepeatability(AnalysisTool):
     """Compute photometric repeatability from multiple measurements of a set of
-    sources. First, a set of per-source quality criteria are applied. Second,
+    stars. First, a set of per-source quality criteria are applied. Second,
     the individual source measurements are grouped together by object index
     and per-group quantities are computed (e.g., a representative S/N for the
     group based on the median of associated per-source measurements). Third,

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -21,8 +21,7 @@
 from __future__ import annotations
 
 __all__ = (
-    
-    "StellarPhotometricRepeatability", 
+    "StellarPhotometricRepeatability",
     "StellarPhotometricResidualsFocalPlane",
 )
 


### PR DESCRIPTION
This PR implements metrics modelPhotRepStar1-4 and psfPhotRepStar1-4 in analysis_tools. All that was required was (1) modifying stellarPhotometricRepeatability.py to use a "RangeSelector" (i.e., select values between an upper and lower threshold) instead of "ThresholdSelector", and (2) implementing the metrics in the matchedVisitQualityCore.yaml pipeline.

Note that only the stellar repeatability metrics were added. Galaxy metrics will require a different implementation since `isolated_star_sources` uses only stars.