### PR TITLE
DM-39089: Handle failure modes in Sasquatch Dispatch

### DIFF
--- a/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
@@ -354,7 +354,8 @@ class SasquatchDispatcher:
                 except ValueError:
                     # Could not extract package timestamp leaving empty
                     pass
-        meta["reference_package"] = ref_package
+        # explicit handle if None was set in the bundle for the package
+        meta["reference_package"] = ref_package or ""
         meta["reference_package_version"] = package_version
         meta["reference_package_timestamp"] = package_timestamp
 
@@ -687,7 +688,9 @@ class SasquatchDispatcher:
                 uploadFailed.append(True)
                 partialUpload = True
 
-        if all(uploadFailed):
+        # There may be no metrics to try to upload, and thus the uploadFailed
+        # list may be empty, check before issuing failure
+        if len(uploadFailed) > 0 and all(uploadFailed):
             raise SasquatchDispatchFailure("All records were unable to be uploaded.")
 
         if partialUpload or recordsTrimmed:

--- a/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
@@ -167,7 +167,7 @@ class SasquatchDispatcher:
     token: str
     """Authentication token used in communicating with the proxy server"""
 
-    namespace: str = "lsst.debug"
+    namespace: str = "lsst.dm"
     """The namespace in Sasquatch in which to write the uploaded metrics"""
 
     def __post_init__(self) -> None:

--- a/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
@@ -105,7 +105,7 @@ class SasquatchDatastore(GenericBaseDatastore):
 
         self.accessToken = self.config.get("accessToken", "na")
 
-        self.namespace = self.config.get("namespace", "lsst.debug")
+        self.namespace = self.config.get("namespace", "lsst.dm")
 
         self._dispatcher = SasquatchDispatcher(self.restProxyUrl, self.accessToken, self.namespace)
 


### PR DESCRIPTION
Handle failure modes in Sasquatch Dispatching where the reference_package is a None value, and when there is no data in a bundle to upload.