### PR TITLE
DM-39143: Implement script for uploading free metrics to Sasquatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ config.log
 
 # Built by sconsUtils
 version.py
-bin/
+/bin/
 
 # Pytest
 tests/.tests

--- a/bin.src/SConscript
+++ b/bin.src/SConscript
@@ -1,0 +1,4 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+
+scripts.BasicSConscript.shebang()

--- a/bin.src/verify_to_sasquatch.py
+++ b/bin.src/verify_to_sasquatch.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from lsst.analysis.tools.bin.verifyToSasquatch import main
+
+if __name__ == "__main__":
+    main()

--- a/doc/lsst.analysis.tools/action-types.rst
+++ b/doc/lsst.analysis.tools/action-types.rst
@@ -12,6 +12,7 @@ Scalar Actions
 
 .. automodapi:: lsst.analysis.tools.actions.scalar
     :no-inherited-members:
+    :no-main-docstr:
 
 Vector Actions
 ==============

--- a/doc/lsst.analysis.tools/index.rst
+++ b/doc/lsst.analysis.tools/index.rst
@@ -48,6 +48,16 @@ The ``lsst.analysis.tools`` package is developed at `github.com/lsst/analysis_to
 
 Jira issues relating to this package can be found using the `analysis_tools <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20analysis_tools>`_ component.
 
+.. _lsst.analysis_tools-scripts:
+
+Script reference
+================
+
+.. toctree::
+   :maxdepth: 1
+
+   scripts/verify_to_sasquatch.py
+
 .. _lsst.analysis_tools-pyapi:
 
 Python API Reference

--- a/doc/lsst.analysis.tools/scripts/verify_to_sasquatch.py.rst
+++ b/doc/lsst.analysis.tools/scripts/verify_to_sasquatch.py.rst
@@ -1,0 +1,3 @@
+.. autoprogram:: lsst.analysis.tools.bin.verifyToSasquatch:makeParser()
+   :prog: verify_to_sasquatch.py
+   :groups:

--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -62,6 +62,12 @@ def makeParser():
         "be specified in any notation recognized by Middleware.",
     )
     parser.add_argument("--dataset", required=True, help="The dataset on which the metrics were measured.")
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Run this command while uploading to the lsst.debug test "
+        "namespace. Any --namespace argument is ignored.",
+    )
 
     api_group = parser.add_argument_group("Sasquatch API arguments")
     api_group.add_argument(
@@ -131,6 +137,9 @@ def _bundle_metrics(
 
 def main():
     args = makeParser().parse_args()
+    if args.test:
+        args.namespace = "lsst.debug"
+
     butler = Butler(args.repo, collections=args.collections, writeable=False)
     metricTypes = {t for t in butler.registry.queryDatasetTypes() if t.storageClass_name == "MetricValue"}
     metricValues = butler.registry.queryDatasets(metricTypes, findFirst=True)

--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -1,0 +1,35 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = [
+    "main",
+]
+
+import argparse
+
+
+def makeParser():
+    parser = argparse.ArgumentParser()
+    return parser
+
+
+def main():
+    makeParser().parse_args()

--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -68,6 +68,9 @@ def makeParser():
         help="Run this command while uploading to the lsst.debug test "
         "namespace. Any --namespace argument is ignored.",
     )
+    parser.add_argument(
+        "--where", default="", help="Butler query to select metric values for upload (default: all values)."
+    )
 
     api_group = parser.add_argument_group("Sasquatch API arguments")
     api_group.add_argument(
@@ -142,7 +145,7 @@ def main():
 
     butler = Butler(args.repo, collections=args.collections, writeable=False)
     metricTypes = {t for t in butler.registry.queryDatasetTypes() if t.storageClass_name == "MetricValue"}
-    metricValues = butler.registry.queryDatasets(metricTypes, findFirst=True)
+    metricValues = butler.registry.queryDatasets(metricTypes, where=args.where, findFirst=True)
     _LOG.info("Found %d metric values in %s.", metricValues.count(), args.collections)
 
     bundles = _bundle_metrics(butler, metricValues)

--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -24,11 +24,66 @@ __all__ = [
 ]
 
 import argparse
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+
+import lsst.verify
+from lsst.analysis.tools.interfaces import MetricMeasurementBundle
+from lsst.daf.butler import Butler, DataCoordinate, DatasetRef
 
 
 def makeParser():
     parser = argparse.ArgumentParser()
     return parser
+
+
+def _bundle_metrics(
+    butler: Butler, metricValues: Iterable[DatasetRef]
+) -> Mapping[tuple[str, str, DataCoordinate], MetricMeasurementBundle]:
+    """Organize free metric values into metric bundles while preserving as much
+    information as practical.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        The Butler repository containing the metric values.
+    metricValues : `~collections.abc.Iterable` [`lsst.daf.butler.DatasetRef`]
+        The datasets to bundle. All references must point to ``MetricValue``
+        datasets.
+
+    Returns
+    -------
+    bundles : `~collections.abc.Mapping`
+        A collection of
+        `lsst.analysis.tools.interfaces.MetricMeasurementBundle`, one for each
+        combination of distinct metadata. The mapping key is a tuple of (run,
+        dataset type, data ID), and the value is the corresponding bundle.
+        To simplify the uploaded schemas, the bundle uses metrics' relative
+        (unqualified) names even if the input measurements were
+        fully-qualified.
+    """
+    bundles = defaultdict(MetricMeasurementBundle)
+    for ref in metricValues:
+        value = butler.get(ref)
+        # MeasurementMetricBundle doesn't validate input.
+        if not isinstance(value, lsst.verify.Measurement):
+            raise ValueError(f"{ref} is not a metric value.")
+
+        # HACK: in general, metric names are fully qualified, and this becomes
+        # the InfluxDB field name. lsst.verify-style metrics have unique names
+        # already, so remove the package qualification.
+        value = lsst.verify.Measurement(
+            value.metric_name.metric, value.quantity, value.blobs.values(), value.extras, value.notes
+        )
+        # These metrics weren't created by actions. Sasquatch requires that
+        # each actionId produce the same metrics on every run (see
+        # https://sasquatch.lsst.io/user-guide/avro.html), so choose something
+        # unique to the metric.
+        actionId = value.metric_name.metric
+
+        bundle = bundles[(ref.run, ref.datasetType.name, ref.dataId)]
+        bundle.setdefault(actionId, []).append(value)
+    return bundles
 
 
 def main():

--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 import argparse
+import datetime
 import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
@@ -70,6 +71,13 @@ def makeParser():
     )
     parser.add_argument(
         "--where", default="", help="Butler query to select metric values for upload (default: all values)."
+    )
+    parser.add_argument(
+        "--date-created",
+        type=datetime.datetime.fromisoformat,
+        help="ISO8601 formatted datetime in UTC for the Measurement creation "
+        "date, e.g. 2021-06-30T22:28:25Z. If not provided, the run time or "
+        "current time is used.",
     )
 
     api_group = parser.add_argument_group("Sasquatch API arguments")
@@ -156,6 +164,7 @@ def main():
             bundle,
             run=run,
             datasetType=datasetType,
+            timestamp=args.date_created,
             datasetIdentifier=args.dataset,
             identifierFields=dataId,
         )

--- a/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
@@ -214,7 +214,9 @@ class SasquatchDispatcher:
         topic_name : `str`
             The name of the kafka topic to create
 
-        returns : `bool`
+        Returns
+        -------
+        status : `bool`
             If this does not encounter an error it will return a True success
             code, else it will return a False code.
 
@@ -446,7 +448,7 @@ class SasquatchDispatcher:
             in the record, and used in creating a unique tag for the uploaded
             dataset type. I.e. the timestamp, and the tag will be unique, and
             each record will belong to one combination of such.
-        datasetIdentifier : `str`
+        datasetIdentifier : `str` or `None`
             A string which will be used in creating unique identifier tags.
         bundle : `MetricMeasurementBundle`
             The bundle containing metric values to upload.
@@ -492,22 +494,22 @@ class SasquatchDispatcher:
         datasetType : `str`
             The dataset type name associated with this
             `MetricMeasurementBundle`
-        timestamp : `str` or `None`
+        timestamp : `datetime.datetime`, optional
             The timestamp to be associated with the measurements in the ingress
             database. If this value is None, timestamp will be set by the run
             time or current time.
-        id : `UUID` or `None`
+        id : `UUID`, optional
             The UUID of the `MetricMeasurementBundle` within the butler. If
             `None`, a new random UUID will be generated so that each record in
             Sasquatch will have a unique value.
-        datasetIdentifier : `str`
-            A string which will be used in creating unique identifier tags.
-        identifierFields: `Mapping` or `None`
+        identifierFields: `Mapping`, optional
             The keys and values in this mapping will be both added as fields
             in the record, and used in creating a unique tag for the uploaded
             dataset type. I.e. the timestamp, and the tag will be unique, and
             each record will belong to one combination of such.
-        extraFields: `Mapping`
+        datasetIdentifier : `str`, optional
+            A string which will be used in creating unique identifier tags.
+        extraFields: `Mapping`, optional
             Extra mapping keys and values that will be added as fields to the
             dispatched record.
 
@@ -617,24 +619,24 @@ class SasquatchDispatcher:
         datasetType : `str`
             The dataset type name associated with this
             `MetricMeasurementBundle`.
-        timestamp : `str` or `None`
+        timestamp : `datetime.datetime`, optional
             The timestamp to be associated with the measurements in the ingress
             database. If this value is None, timestamp will be set by the run
             time or current time.
-        id : `UUID` or `None`
+        id : `UUID`, optional
             The UUID of the `MetricMeasurementBundle` within the Butler. If
             `None`, a new random UUID will be generated so that each record in
             Sasquatch will have a unique value.
-        datasetIdentifier : `str` or `None`
+        datasetIdentifier : `str`, optional
             A string which will be used in creating unique identifier tags. If
             `None`, a default value will be inserted.
-        identifierFields: `Mapping` or `None`
+        identifierFields: `Mapping`, optional
             The keys and values in this mapping will be both added as fields
             in the record, and used in creating a unique tag for the uploaded
             dataset type. I.e. the timestamp, and the tag will be unique, and
             each record will belong to one combination of such. Examples of
             entries would be things like visit or tract.
-        extraFields: `Mapping`
+        extraFields: `Mapping`, optional
             Extra mapping keys and values that will be added as fields to the
             dispatched record.
 
@@ -714,14 +716,14 @@ class SasquatchDispatcher:
         ref : `DatasetRef`
             The `Butler` dataset ref corresponding to the input
             `MetricMeasurementBundle`.
-        timestamp : `str` or `None`
+        timestamp : `datetime.datetime`, optional
             The timestamp to be associated with the measurements in the ingress
             database. If this value is None, timestamp will be set by the run
             time or current time.
-        extraFields: `Mapping` or `None`
+        extraFields: `Mapping`, optional
             Extra mapping keys and values that will be added as fields to the
             dispatched record if not None.
-        datasetIdentifier : `str` or `None`
+        datasetIdentifier : `str`, optional
             A string which will be used in creating unique identifier tags. If
             None, a default value will be inserted.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 110
 max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503, E203
 exclude =
-  bin,
+  ./bin,
   doc/conf.py,
   **/*/__init__.py,
   **/*/version.py,

--- a/tests/test_verifyToSasquatch.py
+++ b/tests/test_verifyToSasquatch.py
@@ -1,0 +1,177 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import tempfile
+import unittest
+
+import astropy.units as u
+import lsst.daf.butler.tests as butlerTests
+from lsst.analysis.tools.bin.verifyToSasquatch import _bundle_metrics
+from lsst.analysis.tools.interfaces import MetricMeasurementBundle
+from lsst.daf.butler import CollectionType, DataCoordinate
+from lsst.verify import Measurement
+
+
+class VerifyToSasquatchTestSuite(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        repo = tempfile.TemporaryDirectory()
+        # TemporaryDirectory warns on leaks; addCleanup also keeps the TD from
+        # getting garbage-collected.
+        self.addCleanup(tempfile.TemporaryDirectory.cleanup, repo)
+        self.butler = butlerTests.makeTestRepo(repo.name)
+
+        butlerTests.addDataIdValue(self.butler, "instrument", "notACam")
+        for visit in [42, 43]:
+            butlerTests.addDataIdValue(self.butler, "visit", visit)
+            for detector in range(4):
+                butlerTests.addDataIdValue(self.butler, "detector", detector)
+        butlerTests.addDatasetType(
+            self.butler,
+            "metricvalue_nopackage_fancyMetric",
+            {"instrument", "visit", "detector"},
+            "MetricValue",
+        )
+        butlerTests.addDatasetType(
+            self.butler,
+            "metricvalue_nopackage_fancierMetric",
+            {"instrument", "visit", "detector"},
+            "MetricValue",
+        )
+        butlerTests.addDatasetType(
+            self.butler, "metricvalue_nopackage_plainMetric", {"instrument"}, "MetricValue"
+        )
+        self.butler.registry.registerCollection("run1", CollectionType.RUN)
+        self.butler.registry.registerCollection("run2", CollectionType.RUN)
+
+    def _standardize(self, dataId):
+        """Convert an arbitrary data ID to a DataCoordinate."""
+        return DataCoordinate.standardize(dataId, universe=self.butler.dimensions)
+
+    def test_bundle_metrics_nometrics(self):
+        refs = self.butler.registry.queryDatasets("metricvalue_nopackage_*", collections=...)
+        bundles = _bundle_metrics(self.butler, refs)
+        # MetricMeasurementBundle.equals ignores metadata
+        self.assertDictEqual(bundles, {})
+
+    def test_bundle_metrics_onemetric(self):
+        m = Measurement("nopackage.fancyMetric", 42.2 * u.s)
+        self.butler.put(
+            m, "metricvalue_nopackage_fancyMetric", run="run1", instrument="notACam", visit=42, detector=2
+        )
+        refs = self.butler.registry.queryDatasets("metricvalue_nopackage_fancyMetric", collections=...)
+        bundles = _bundle_metrics(self.butler, refs)
+        # MetricMeasurementBundle.equals ignores metadata
+        self.assertDictEqual(
+            bundles,
+            {
+                (
+                    "run1",
+                    "metricvalue_nopackage_fancyMetric",
+                    self._standardize({"instrument": "notACam", "visit": 42, "detector": 2}),
+                ): MetricMeasurementBundle({"fancyMetric": [Measurement(m.metric_name.metric, m.quantity)]}),
+            },
+        )
+
+    def test_bundle_metrics_onemetrictwice(self):
+        m2 = Measurement("nopackage.fancyMetric", 42.2 * u.s)
+        self.butler.put(
+            m2, "metricvalue_nopackage_fancyMetric", run="run1", instrument="notACam", visit=42, detector=2
+        )
+        m1 = Measurement("nopackage.fancyMetric", 43.1 * u.m)
+        self.butler.put(
+            m1, "metricvalue_nopackage_fancyMetric", run="run1", instrument="notACam", visit=43, detector=1
+        )
+        refs = self.butler.registry.queryDatasets("metricvalue_nopackage_fancyMetric", collections=...)
+        bundles = _bundle_metrics(self.butler, refs)
+        # MetricMeasurementBundle.equals ignores metadata
+        self.assertDictEqual(
+            bundles,
+            {
+                (
+                    "run1",
+                    "metricvalue_nopackage_fancyMetric",
+                    self._standardize({"instrument": "notACam", "visit": 42, "detector": 2}),
+                ): MetricMeasurementBundle(
+                    {"fancyMetric": [Measurement(m2.metric_name.metric, m2.quantity)]}
+                ),
+                (
+                    "run1",
+                    "metricvalue_nopackage_fancyMetric",
+                    self._standardize({"instrument": "notACam", "visit": 43, "detector": 1}),
+                ): MetricMeasurementBundle(
+                    {"fancyMetric": [Measurement(m1.metric_name.metric, m1.quantity)]}
+                ),
+            },
+        )
+
+    def test_bundle_metrics_threemetrics(self):
+        m2 = Measurement("nopackage.fancyMetric", 42.2 * u.s)
+        self.butler.put(
+            m2, "metricvalue_nopackage_fancyMetric", run="run1", instrument="notACam", visit=42, detector=2
+        )
+        m1 = Measurement("nopackage.fancierMetric", 43.1 * u.m)
+        self.butler.put(
+            m1, "metricvalue_nopackage_fancierMetric", run="run2", instrument="notACam", visit=43, detector=1
+        )
+        m_ = Measurement("nopackage.plainMetric", 127.0 * u.kg)
+        self.butler.put(m_, "metricvalue_nopackage_plainMetric", run="run1", instrument="notACam")
+        refs = self.butler.registry.queryDatasets("metricvalue_nopackage_*", collections=...)
+        bundles = _bundle_metrics(self.butler, refs)
+        # MetricMeasurementBundle.equals ignores metadata
+        self.assertDictEqual(
+            bundles,
+            {
+                (
+                    "run1",
+                    "metricvalue_nopackage_fancyMetric",
+                    self._standardize({"instrument": "notACam", "visit": 42, "detector": 2}),
+                ): MetricMeasurementBundle(
+                    {"fancyMetric": [Measurement(m2.metric_name.metric, m2.quantity)]}
+                ),
+                (
+                    "run2",
+                    "metricvalue_nopackage_fancierMetric",
+                    self._standardize({"instrument": "notACam", "visit": 43, "detector": 1}),
+                ): MetricMeasurementBundle(
+                    {"fancierMetric": [Measurement(m1.metric_name.metric, m1.quantity)]}
+                ),
+                (
+                    "run1",
+                    "metricvalue_nopackage_plainMetric",
+                    self._standardize({"instrument": "notACam"}),
+                ): MetricMeasurementBundle(
+                    {"plainMetric": [Measurement(m_.metric_name.metric, m_.quantity)]}
+                ),
+            },
+        )
+
+    def test_bundle_metrics_badmetric(self):
+        butlerTests.addDatasetType(
+            self.butler, "metricvalue_nopackage_notAMetric", {"instrument", "visit"}, "StructuredDataDict"
+        )
+        self.butler.put(
+            {"foo": "bar"}, "metricvalue_nopackage_notAMetric", run="run1", instrument="notACam", visit=42
+        )
+        refs = self.butler.registry.queryDatasets("metricvalue_nopackage_notAMetric", collections=...)
+        with self.assertRaises(ValueError):
+            _bundle_metrics(self.butler, refs)

--- a/ups/analysis_tools.table
+++ b/ups/analysis_tools.table
@@ -15,4 +15,5 @@ setupRequired(skymap)
 # The following is boilerplate for all packages.
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
+envPrepend(PATH, ${PRODUCT_DIR}/bin)
 envPrepend(DAF_BUTLER_CONFIG_PATH, ${PRODUCT_DIR}/python/lsst/analysis/tools/interfaces/datastore)


### PR DESCRIPTION
This PR adds a new script, `verify_to_sasquatch.py`, that provides backwards-compatibility support for `lsst.verify` metrics persisted directly to a Butler repository. The script implements functionality similar to `dispatch_verify.py`, but backed by `SasquatchDispatcher`.