### PR TITLE
DM-39672: Don't use a `set` as the default for a config ListField.

### DIFF
--- a/python/lsst/analysis/tools/actions/plot/histPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/histPlot.py
@@ -80,7 +80,7 @@ class HistStatsPanel(Config):
     statsLabels = ListField[str](
         doc="list specifying the labels for stats",
         length=3,
-        default={"N$_{{data}}$", "Med", "${{\\sigma}}_{{MAD}}$"},
+        default=("N$_{{data}}$", "Med", "${{\\sigma}}_{{MAD}}$"),
     )
     stat1 = ListField[str](
         doc="A list specifying the vector keys of the first scalar statistic to be shown in this panel."


### PR DESCRIPTION
Set's iteration order is nondeterministic across different processes, while ListField remembers that order, so this makes configurations generated in different processes spuriously unequal.