### PR TITLE
DM-39412: Add Jenkins build ID to ap_verify Sasquatch metadata

### DIFF
--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 import argparse
+import copy
 import datetime
 import logging
 from collections import defaultdict
@@ -95,6 +96,61 @@ def makeParser():
     api_group.add_argument("--token", default="na", help="Authentication token for the proxy server.")
 
     return parser
+
+
+class _AppendDict(argparse.Action):
+    """An action analogous to the build-in 'append' that appends to a `dict`
+    instead of a `list`.
+
+    Inputs are assumed to be strings in the form "key=value"; any input that
+    does not contain exactly one "=" character is invalid. If the default value
+    is non-empty, the default key-value pairs may be overwritten by values from
+    the command line.
+    """
+
+    def __init__(
+        self,
+        option_strings,
+        dest,
+        nargs=None,
+        const=None,
+        default=None,
+        type=None,
+        choices=None,
+        required=False,
+        help=None,
+        metavar=None,
+    ):
+        if default is None:
+            default = {}
+        if not isinstance(default, Mapping):
+            argname = option_strings if option_strings else metavar if metavar else dest
+            raise TypeError(f"Default for {argname} must be a mapping or None, got {default!r}.")
+        super().__init__(option_strings, dest, nargs, const, default, type, choices, required, help, metavar)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # argparse doesn't make defensive copies, so namespace.dest may be
+        # the same object as self.default. Do the copy ourselves and avoid
+        # modifying the object previously in namespace.dest.
+        mapping = copy.copy(getattr(namespace, self.dest))
+
+        # Sometimes values is a copy of default instead of an input???
+        if isinstance(values, Mapping):
+            mapping.update(values)
+        else:
+            # values may be either a string or list of strings, depending on
+            # nargs. Unsafe to test for Sequence, because a scalar string
+            # passes.
+            if not isinstance(values, list):
+                values = [values]
+            for value in values:
+                vars = value.split("=")
+                if len(vars) != 2:
+                    raise ValueError(f"Argument {value!r} does not match format 'key=value'.")
+                mapping[vars[0]] = vars[1]
+
+        # Other half of the defensive copy.
+        setattr(namespace, self.dest, mapping)
 
 
 def _bundle_metrics(

--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -80,6 +80,14 @@ def makeParser():
         "date, e.g. 2021-06-30T22:28:25Z. If not provided, the run time or "
         "current time is used.",
     )
+    parser.add_argument(
+        "--extra",
+        action=_AppendDict,
+        help="Extra field (in the form key=value) to be added to any records "
+        "uploaded to Sasquatch. See SasquatchDispatcher.dispatch and "
+        ".dispatchRef for more details. The --extra argument can be passed "
+        "multiple times.",
+    )
 
     api_group = parser.add_argument_group("Sasquatch API arguments")
     api_group.add_argument(
@@ -223,4 +231,5 @@ def main():
             timestamp=args.date_created,
             datasetIdentifier=args.dataset,
             identifierFields=dataId,
+            extraFields=args.extra,
         )


### PR DESCRIPTION
This PR implements an `--extras` command-line argument for `verify_to_sasquatch.py`, allowing a dict for `SasquatchDispatcher.dispatch` to be specified on the command line. This will be used by the `scipipe/ap_verify` and `sqre/verify_drp_metrics` jobs (see lsst-dm/jenkins-dm-jobs#955) to add Jenkins-specific metadata to the upload.