### PR TITLE
DM-38974: Move photometric repeatability metrics from faro to analysis_tools

### DIFF
--- a/python/lsst/analysis/tools/actions/vector/calcBinnedStats.py
+++ b/python/lsst/analysis/tools/actions/vector/calcBinnedStats.py
@@ -105,7 +105,7 @@ class CalcBinnedStatsAction(KeyedDataAction):
         for name, value in action(data, **kwargs).items():
             results[getattr(self, f"name_{name}").format(**kwargs_format)] = value
 
-        values = cast(Vector, data[self.selector_range.key][mask])  # type: ignore
+        values = cast(Vector, data[self.selector_range.vectorKey][mask])  # type: ignore
         valid = np.sum(np.isfinite(values)) > 0
 
         results[self.name_select_maximum.format(**kwargs_format)] = cast(

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -145,7 +145,7 @@ class TestVectorActions(unittest.TestCase):
     # VectorActions with their own files
 
     def testCalcBinnedStats(self):
-        selector = RangeSelector(key="r_vector", minimum=0, maximum=self.size)
+        selector = RangeSelector(vectorKey="r_vector", minimum=0, maximum=self.size)
         prefix = "a_"
         stats = CalcBinnedStatsAction(name_prefix=prefix, selector_range=selector, key_vector="r_vector")
         result = stats(self.data)
@@ -489,7 +489,7 @@ class TestVectorSelectors(unittest.TestCase):
         np.testing.assert_array_equal(result, truth)
 
     def testRangeSelector(self):
-        selector = RangeSelector(key="r_psfFlux", minimum=np.nextafter(20, 30), maximum=50)
+        selector = RangeSelector(vectorKey="r_psfFlux", minimum=np.nextafter(20, 30), maximum=50)
         self._checkSchema(selector, ["r_psfFlux"])
         result = self.data["r_psfFlux"][selector(self.data)]
         truth = [30, 40]


### PR DESCRIPTION
I fixed a few stray instances of key --> vectorKey in calls to RangeSelector. Passing Jenkins run at https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/39255/pipeline