### PR TITLE
DM-39332: Fix the PF1 metric to be threshold relative to mean

### DIFF
--- a/python/lsst/analysis/tools/actions/plot/histPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/histPlot.py
@@ -559,7 +559,7 @@ class HistPlot(PlotAction):
             else:
                 reference_value = self.panels[panel].referenceValue
                 reference_label = "${{\\mu_{{ref}}}}$: {}".format(reference_value)
-        ax2.axvline(reference_value, ls="-", lw=1, c="black", zorder=0, label=reference_label)
+            ax2.axvline(reference_value, ls="-", lw=1, c="black", zorder=0, label=reference_label)
         if self.panels[panel].histDensity:
             ref_x = np.arange(panel_range[0], panel_range[1], (panel_range[1] - panel_range[0]) / 100.0)
             ref_mean = self.panels[panel].referenceValue

--- a/python/lsst/analysis/tools/actions/plot/histPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/histPlot.py
@@ -160,6 +160,11 @@ class HistPanel(Config):
         default=None,
         optional=True,
     )
+    refRelativeToMedian = Field[bool](
+        doc="Is the referenceValue meant to be an offset from the median?",
+        default=False,
+        optional=True,
+    )
     histDensity = Field[bool](
         doc="Whether to plot the histogram as a normalized probability distribution. Must also "
         "provide a value for referenceValue",
@@ -452,7 +457,8 @@ class HistPlot(PlotAction):
             # If histDensity is True, also plot a reference PDF with
             # mean = referenceValue and sigma = 1 for reference.
             if self.panels[panel].referenceValue is not None:
-                ax = self._addReferenceLines(ax, panel, panel_range, legend_font_size=legend_font_size)
+                # if self.panels[panel].refRelativeToMedian:
+                ax = self._addReferenceLines(ax, panel, panel_range, meds, legend_font_size=legend_font_size)
 
             # Check if we should use the default stats panel or if a custom one
             # has been created.
@@ -536,7 +542,7 @@ class HistPlot(PlotAction):
         mad = sigmaMad(data)
         return num, med, mad
 
-    def _addReferenceLines(self, ax, panel, panel_range, legend_font_size=7):
+    def _addReferenceLines(self, ax, panel, panel_range, meds, legend_font_size=7):
         """Draw the vertical reference line and density curve (if requested)
         on the panel.
         """
@@ -548,10 +554,13 @@ class HistPlot(PlotAction):
         if self.panels[panel].histDensity:
             reference_label = None
         else:
-            reference_label = "${{\\mu_{{ref}}}}$: {}".format(self.panels[panel].referenceValue)
-        ax2.axvline(
-            self.panels[panel].referenceValue, ls="-", lw=1, c="black", zorder=0, label=reference_label
-        )
+            if self.panels[panel].refRelativeToMedian:
+                reference_value = self.panels[panel].referenceValue + meds[0]
+                reference_label = "${{\\mu_{{ref}}}}$: {}".format(self.panels[panel].referenceValue + meds[0])
+            else:
+                reference_value = self.panels[panel].referenceValue
+                reference_label = "${{\\mu_{{ref}}}}$: {}".format(self.panels[panel].referenceValue)
+        ax2.axvline(reference_value, ls="-", lw=1, c="black", zorder=0, label=reference_label)
         if self.panels[panel].histDensity:
             ref_x = np.arange(panel_range[0], panel_range[1], (panel_range[1] - panel_range[0]) / 100.0)
             ref_mean = self.panels[panel].referenceValue

--- a/python/lsst/analysis/tools/actions/plot/histPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/histPlot.py
@@ -457,7 +457,6 @@ class HistPlot(PlotAction):
             # If histDensity is True, also plot a reference PDF with
             # mean = referenceValue and sigma = 1 for reference.
             if self.panels[panel].referenceValue is not None:
-                # if self.panels[panel].refRelativeToMedian:
                 ax = self._addReferenceLines(ax, panel, panel_range, meds, legend_font_size=legend_font_size)
 
             # Check if we should use the default stats panel or if a custom one
@@ -556,10 +555,10 @@ class HistPlot(PlotAction):
         else:
             if self.panels[panel].refRelativeToMedian:
                 reference_value = self.panels[panel].referenceValue + meds[0]
-                reference_label = "${{\\mu_{{ref}}}}$: {}".format(self.panels[panel].referenceValue + meds[0])
+                reference_label = "${{\\mu_{{ref}}}}$: {}".format(reference_value)
             else:
                 reference_value = self.panels[panel].referenceValue
-                reference_label = "${{\\mu_{{ref}}}}$: {}".format(self.panels[panel].referenceValue)
+                reference_label = "${{\\mu_{{ref}}}}$: {}".format(reference_value)
         ax2.axvline(reference_value, ls="-", lw=1, c="black", zorder=0, label=reference_label)
         if self.panels[panel].histDensity:
             ref_x = np.arange(panel_range[0], panel_range[1], (panel_range[1] - panel_range[0]) / 100.0)

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -106,11 +106,13 @@ class StellarPhotometricRepeatability(AnalysisTool):
 
         # Compute summary statistics on filtered groups
         self.process.calculateActions.photRepeatStdev = MedianAction(vectorKey="perGroupStdevFiltered")
+        # import pdb; pdb.set_trace()
         self.process.calculateActions.photRepeatOutlier = FracThreshold(
             vectorKey="perGroupStdevFiltered",
             op="ge",
             threshold=self.PA2Value,
             percent=True,
+            relative_to_median=True,
         )
         self.process.calculateActions.photRepeatNsources = CountAction(vectorKey="perGroupStdevFiltered")
 
@@ -125,6 +127,8 @@ class StellarPhotometricRepeatability(AnalysisTool):
         self.produce.plot.panels["panel_rms"].statsPanel.stat3 = ["photRepeatOutlier"]
 
         self.produce.plot.panels["panel_rms"].referenceValue = self.PA2Value
+        self.produce.plot.panels["panel_rms"].refRelativeToMedian = True
+
         self.produce.plot.panels["panel_rms"].label = "rms (mmag)"
         self.produce.plot.panels["panel_rms"].hists = dict(perGroupStdevFiltered="Filtered per group rms")
 

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -106,7 +106,6 @@ class StellarPhotometricRepeatability(AnalysisTool):
 
         # Compute summary statistics on filtered groups
         self.process.calculateActions.photRepeatStdev = MedianAction(vectorKey="perGroupStdevFiltered")
-        # import pdb; pdb.set_trace()
         self.process.calculateActions.photRepeatOutlier = FracThreshold(
             vectorKey="perGroupStdevFiltered",
             op="ge",


### PR DESCRIPTION
This ticket makes the PF1 metric calculation ("stellarPhotRepeatOutlierFraction") use a threshold _relative to the median_ as defined in the SRD, rather than taking a simple threshold in rms. It involved changing the ScalarAction and HistPlot.