### PR TITLE
DM-41598: Add missing abstract methods to SasquatchDatastore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ version.py
 
 # Pytest
 tests/.tests
+tests/tmp*
 pytest_session.txt
 .cache/
 .pytest_cache

--- a/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
@@ -29,7 +29,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.daf.butler import DatasetRef, DatasetTypeNotSupportedError, StorageClass
-from lsst.daf.butler.datastore import DatasetRefURIs
+from lsst.daf.butler.datastore import DatasetRefURIs, DatastoreOpaqueTable
 from lsst.daf.butler.datastore.generic_base import GenericBaseDatastore
 from lsst.daf.butler.datastore.record_data import DatastoreRecordData
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
@@ -117,6 +117,13 @@ class SasquatchDatastore(GenericBaseDatastore):
             raise DatasetTypeNotSupportedError(
                 f"Could not put dataset type {ref.datasetType} with Sasquatch datastore"
             )
+
+    def put_new(self, in_memory_dataset: Any, dataset_ref: DatasetRef) -> Mapping[str, DatasetRef]:
+        # Docstring inherited from the base class.
+        self.put(in_memory_dataset, dataset_ref)
+        # Sasquatch is a sort of ephemeral, because we do not store its
+        # datastore records in registry, so return empty dict.
+        return {}
 
     def addStoredItemInfo(self, refs: Iterable[DatasetRef], infos: Iterable[Any]) -> None:
         raise NotImplementedError()
@@ -223,3 +230,7 @@ class SasquatchDatastore(GenericBaseDatastore):
     @classmethod
     def setConfigRoot(cls, root: str, config: Config, full: Config, overwrite: bool = True) -> None:
         pass
+
+    def get_opaque_table_definitions(self) -> Mapping[str, DatastoreOpaqueTable]:
+        # Docstring inherited from the base class.
+        return {}

--- a/tests/test_sasquatchDatastore.py
+++ b/tests/test_sasquatchDatastore.py
@@ -1,0 +1,76 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from unittest.mock import patch
+
+import astropy.units as u
+import lsst.daf.butler.tests as butlerTests
+from lsst.analysis.tools.interfaces import MetricMeasurementBundle
+from lsst.analysis.tools.interfaces.datastore import SasquatchDispatcher
+from lsst.daf.butler import CollectionType, Config
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+from lsst.verify import Measurement
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+CONFIG_FILE = os.path.join(TESTDIR, "config", "butler-sasquatch.yaml")
+
+
+class SasquatchDatastoreTest(unittest.TestCase):
+    def setUp(self):
+        self.root = makeTestTempDir(TESTDIR)
+
+        config = Config()
+        config["datastore", "cls"] = "lsst.analysis.tools.interfaces.datastore.SasquatchDatastore"
+        config["datastore", "restProxyUrl"] = "https://example.com/sasquatch-rest-proxy"
+
+        dataIds = {
+            "instrument": ["DummyCam"],
+            "physical_filter": ["d-r"],
+            "visit": [42, 43, 44],
+            "detector": [1, 2, 3],
+        }
+        self.butler = butlerTests.makeTestRepo(self.root, dataIds, config=config)
+
+        butlerTests.addDatasetType(
+            self.butler, "Metrics", {"instrument", "visit", "detector"}, "MetricMeasurementBundle"
+        )
+        self.butler.registry.registerCollection("run1", CollectionType.RUN)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def test_put(self):
+        """Simple test for put method."""
+        m = Measurement("nopackage.fancyMetric", 42.2 * u.s)
+        bundle = MetricMeasurementBundle({"m": [m]})
+
+        # Patch dispatcher method to check parameters.
+        with patch.object(SasquatchDispatcher, "dispatchRef") as mock_method:
+            self.butler.put(bundle, "Metrics", run="run1", instrument="DummyCam", visit=42, detector=2)
+
+        mock_method.assert_called()
+        self.assertIs(mock_method.call_args[0][0], bundle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Also adds a trivial unit test for SasquatchDatastore to verify that it can be instantiated and simple `Butler.put` works on it.