### PR TITLE
Fix broken link to doc on pipelines.lsst.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,5 +6,5 @@ The Analysis Tools package is designed to assist in the creation of quality assu
 The intention is that users have the flexibility to construct complex data analysis tasks from a set of simple building blocks.
 Each analysis tool allows users to generate consistent, repeatable and high-quality plots and metrics, regardless of which dataset they are run on.
 
-For more information on using the Analysis Tools package, please see the `documentation on pipelines.lsst.io <https://pipelines.lsst.io/modules/lsst.analysis_tools/index.html>`_.
+For more information on using the Analysis Tools package, please see the `documentation on pipelines.lsst.io <https://pipelines.lsst.io/v/daily/modules/lsst.analysis.tools/index.html>`_.
 As this package is still under active development, it may also be useful to refer to the latest `daily build of the documentation on pipelines.lsst.io <https://pipelines.lsst.io/v/daily/modules/lsst.analysis.tools/index.html>`_ as well.


### PR DESCRIPTION
Alternative link would be:
https://pipelines.lsst.io/modules/lsst.analysis.tools/index.html
but I think the one in the PR is more helpful.