### PR TITLE
DM-42685 Add a Tensor interface to analysis tools

### DIFF
--- a/python/lsst/analysis/tools/contexts/_baseContext.py
+++ b/python/lsst/analysis/tools/contexts/_baseContext.py
@@ -68,12 +68,10 @@ class ContextApplier:
     @overload
     def __get__(
         self, instance: AnalysisAction, klass: type[AnalysisAction] | None = None
-    ) -> Callable[[ContextType], None]:
-        ...
+    ) -> Callable[[ContextType], None]: ...
 
     @overload
-    def __get__(self, instance: None, klass: type[AnalysisAction] | None = None) -> ContextApplier:
-        ...
+    def __get__(self, instance: None, klass: type[AnalysisAction] | None = None) -> ContextApplier: ...
 
     def __get__(
         self, instance: AnalysisAction | None, klass: type[AnalysisAction] | None = None

--- a/python/lsst/analysis/tools/interfaces/_actions.py
+++ b/python/lsst/analysis/tools/interfaces/_actions.py
@@ -45,7 +45,7 @@ import lsst.pex.config as pexConfig
 from lsst.pex.config.configurableActions import ConfigurableAction, ConfigurableActionField
 
 from ..contexts import ContextApplier
-from ._interfaces import KeyedData, KeyedDataSchema, MetricResultType, PlotResultType, Scalar, Vector
+from ._interfaces import KeyedData, KeyedDataSchema, MetricResultType, PlotResultType, Scalar, Tensor, Vector
 
 
 class AnalysisAction(ConfigurableAction):
@@ -152,6 +152,16 @@ class VectorAction(AnalysisAction):
 
     @abstractmethod
     def __call__(self, data: KeyedData, **kwargs) -> Vector:
+        raise NotImplementedError("This is not implemented on the base class")
+
+
+class TensorAction(AnalysisAction):
+    """A `TensorAction` is an `AnalysisAction` that returns a `Tensor` when
+    called.
+    """
+
+    @abstractmethod
+    def __call__(self, data: KeyedData, **kwargs) -> Tensor:
         raise NotImplementedError("This is not implemented on the base class")
 
 

--- a/python/lsst/analysis/tools/interfaces/_analysisTools.py
+++ b/python/lsst/analysis/tools/interfaces/_analysisTools.py
@@ -39,8 +39,7 @@ from ._stages import BasePrep, BaseProcess, BaseProduce
 
 @runtime_checkable
 class _HasOutputNames(Protocol):
-    def getOutputNames(self, config: pexConfig.Config | None = None) -> Iterable[str]:
-        ...
+    def getOutputNames(self, config: pexConfig.Config | None = None) -> Iterable[str]: ...
 
 
 def _finalizeWrapper(
@@ -116,6 +115,7 @@ class AnalysisTool(AnalysisAction):
     The stages themselves are also configurable, allowing control over various
     aspects of the individual `AnalysisAction`\ s.
     """
+
     prep = ConfigurableActionField[AnalysisAction](doc="Action to run to prepare inputs", default=BasePrep)
     process = ConfigurableActionField[AnalysisAction](
         doc="Action to process data into intended form", default=BaseProcess
@@ -177,9 +177,9 @@ class AnalysisTool(AnalysisAction):
         kwargs["metric_tags"] = list(self.metric_tags or ())
         prepped: KeyedData = self.prep(data, **kwargs)  # type: ignore
         processed: KeyedData = self.process(prepped, **kwargs)  # type: ignore
-        finalized: Mapping[str, PlotTypes] | PlotTypes | Mapping[
-            str, Measurement
-        ] | Measurement | JointResults = self.produce(
+        finalized: (
+            Mapping[str, PlotTypes] | PlotTypes | Mapping[str, Measurement] | Measurement | JointResults
+        ) = self.produce(
             processed, **kwargs
         )  # type: ignore
         return self._process_single_results(finalized)

--- a/python/lsst/analysis/tools/interfaces/_interfaces.py
+++ b/python/lsst/analysis/tools/interfaces/_interfaces.py
@@ -64,15 +64,14 @@ class Tensor(Protocol):
     ``input_tensor`` as if it were a numpy object, one would do
     ``image = np.from_dlpack(input_tensor)``.
     """
+
     ndim: int
     shape: tuple[int, ...]
     strides: tuple[int, ...]
 
-    def __dlpack__(self, /, *, stream: int | None = ...) -> Any:
-        ...
+    def __dlpack__(self, /, *, stream: int | None = ...) -> Any: ...
 
-    def __dlpack_device__(self) -> tuple[int, int]:
-        ...
+    def __dlpack_device__(self) -> tuple[int, int]: ...
 
 
 class ScalarMeta(ABCMeta):

--- a/python/lsst/analysis/tools/interfaces/_interfaces.py
+++ b/python/lsst/analysis/tools/interfaces/_interfaces.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 __all__ = (
+    "Tensor",
     "Scalar",
     "ScalarType",
     "KeyedData",
@@ -34,13 +35,44 @@ __all__ = (
 
 from abc import ABCMeta
 from numbers import Number
-from typing import Any, Iterable, Mapping, MutableMapping, TypeAlias
+from typing import Any, Iterable, Mapping, MutableMapping, Protocol, TypeAlias, runtime_checkable
 
 import numpy as np
 from healsparse import HealSparseMap
 from lsst.verify import Measurement
 from matplotlib.figure import Figure
 from numpy.typing import NDArray
+
+
+@runtime_checkable
+class Tensor(Protocol):
+    r"""This is an interface only class and is intended to represent data that
+    is 2+ dimensions.
+
+    Technically one could use this for scalars or 1D arrays,
+    but for those the Scalar or Vector interface should be preferred.
+
+    `Tensor`\ s abstract around the idea of a multidimensional array, and work
+    with a variety of backends including Numpy, CuPy, Tensorflow, PyTorch,
+    MXNet, TVM, and mpi4py. This intentionally has a minimum interface to
+    comply with the industry standard dlpack which ensures each of these
+    backend native types will work.
+
+    To ensure that a `Tensor` is in a desired container (e.g. ndarray) one can
+    call the corresponding ``from_dlpack`` method. Whenever possible this will
+    be a zero copy action. For instance to work with a Tensor named
+    ``input_tensor`` as if it were a numpy object, one would do
+    ``image = np.from_dlpack(input_tensor)``.
+    """
+    ndim: int
+    shape: tuple[int, ...]
+    strides: tuple[int, ...]
+
+    def __dlpack__(self, /, *, stream: int | None = ...) -> Any:
+        ...
+
+    def __dlpack_device__(self) -> tuple[int, int]:
+        ...
 
 
 class ScalarMeta(ABCMeta):
@@ -72,18 +104,18 @@ Vector = NDArray
 like an NDArray should be considered a Vector.
 """
 
-KeyedData = MutableMapping[str, Vector | Scalar | HealSparseMap]
+KeyedData = MutableMapping[str, Vector | Scalar | HealSparseMap | Tensor]
 """KeyedData is an interface where either a `Vector` or `Scalar` can be
 retrieved using a key which is of str type.
 """
 
-KeyedDataTypes = MutableMapping[str, type[Vector] | ScalarType | type[HealSparseMap]]
+KeyedDataTypes = MutableMapping[str, type[Vector] | ScalarType | type[HealSparseMap] | type[Tensor]]
 r"""A mapping of str keys to the Types which are valid in `KeyedData` objects.
 This is useful in conjunction with `AnalysisAction`\ 's ``getInputSchema`` and
 ``getOutputSchema`` methods.
 """
 
-KeyedDataSchema = Iterable[tuple[str, type[Vector] | ScalarType | type[HealSparseMap]]]
+KeyedDataSchema = Iterable[tuple[str, type[Vector] | ScalarType | type[HealSparseMap] | type[Tensor]]]
 r"""An interface that represents a type returned by `AnalysisAction`\ 's
 ``getInputSchema`` and ``getOutputSchema`` methods.
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 110
 max-doc-length = 79
-ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503, E203
+ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503, E203, E704
 exclude =
 	./bin,
 	doc/conf.py,


### PR DESCRIPTION
This commit adds an interface that can be used to represent multi-dimensional data like images, or stacks of images. It uses an industry standard interface to ensure analysis tools can work with a wide variety of data types from numpy arrays to pytorch models.