### PR TITLE
DM-42685-hotfix: Fix breakage in BasePrep

### DIFF
--- a/python/lsst/analysis/tools/interfaces/_stages.py
+++ b/python/lsst/analysis/tools/interfaces/_stages.py
@@ -87,14 +87,19 @@ class BasePrep(KeyedDataAction):
                 # ignore type since there is not fully proper mypy support for
                 # vector type casting. In the future there will be, and this
                 # makes it clearer now what type things should be.
-                result[key] = cast(Vector, result[key])[mask]  # type: ignore
+                tempFormat = key.format_map(kwargs)
+                result[tempFormat] = cast(Vector, result[tempFormat])[mask]  # type: ignore
         return result
 
     def addInputSchema(self, inputSchema: KeyedDataSchema) -> None:
         existing = list(self.keysToLoad)
-        for name, _ in inputSchema:
+        existingVectors = list(self.vectorKeys)
+        for name, typ in inputSchema:
             existing.append(name)
+            if typ == Vector:
+                existingVectors.append(name)
         self.keysToLoad = existing
+        self.vectorKeys = existingVectors
 
 
 class BaseProcess(KeyedDataAction):


### PR DESCRIPTION
The ticket adding the Tensor interface make a change to BasePrep to make it more logically sound to the types that are possible in keyed data. This unfortunately overlooked usage that existed that relied on ill defined behavior. This is a fixup to that, restoring existing behavior is a slightly more gaurded way.