### PR TITLE
DM-42685-hotfix2 Make BasePrep.addInputSchema idempotent

### DIFF
--- a/python/lsst/analysis/tools/interfaces/_stages.py
+++ b/python/lsst/analysis/tools/interfaces/_stages.py
@@ -98,8 +98,8 @@ class BasePrep(KeyedDataAction):
             existing.append(name)
             if typ == Vector:
                 existingVectors.append(name)
-        self.keysToLoad = existing
-        self.vectorKeys = existingVectors
+        self.keysToLoad = set(existing)
+        self.vectorKeys = set(existingVectors)
 
 
 class BaseProcess(KeyedDataAction):


### PR DESCRIPTION
Add input schema was adding the same vectors multiple times due to how serialization was happening with pickle. Make this idempotent across the number of times this method is called. This is also a good change to make to guard against mistakes by the user specifying a vector multiple times.