### PR TITLE
DM-42941: Using default axis labels for astrom and photom focalPlanePlots

### DIFF
--- a/python/lsst/analysis/tools/atools/astrometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/astrometricRepeatability.py
@@ -153,8 +153,6 @@ class StellarAstrometricResidualsRAFocalPlanePlot(StellarAstrometricResidualsBas
         self.process.buildActions.residual.buildAction.buildAction = RAcosDec()
 
         self.produce = FocalPlanePlot()
-        self.produce.xAxisLabel = "x (focal plane)"
-        self.produce.yAxisLabel = "y (focal plane)"
         self.produce.zAxisLabel = "RAcos(Dec) - RAcos(Dec)$_{mean}$ (mArcsec)"
 
 
@@ -171,8 +169,6 @@ class StellarAstrometricResidualStdDevRAFocalPlanePlot(StellarAstrometricResidua
 
         self.produce = FocalPlanePlot()
         self.produce.statistic = "std"
-        self.produce.xAxisLabel = "x (focal plane)"
-        self.produce.yAxisLabel = "y (focal plane)"
         self.produce.zAxisLabel = "Std(RAcos(Dec) - RAcos(Dec)$_{mean}$) (mArcsec)"
 
 
@@ -188,8 +184,6 @@ class StellarAstrometricResidualsDecFocalPlanePlot(StellarAstrometricResidualsBa
         self.process.buildActions.residual.buildAction.buildAction.vectorKey = "coord_dec"
 
         self.produce = FocalPlanePlot()
-        self.produce.xAxisLabel = "x (focal plane)"
-        self.produce.yAxisLabel = "y (focal plane)"
         self.produce.zAxisLabel = "Dec - Dec$_{mean}$ (mArcsec)"
 
 
@@ -206,8 +200,6 @@ class StellarAstrometricResidualStdDevDecFocalPlanePlot(StellarAstrometricResidu
 
         self.produce = FocalPlanePlot()
         self.produce.statistic = "std"
-        self.produce.xAxisLabel = "x (focal plane)"
-        self.produce.yAxisLabel = "y (focal plane)"
         self.produce.zAxisLabel = "Std(Dec - Dec$_{mean}$) (mArcsec)"
 
 

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -194,6 +194,4 @@ class StellarPhotometricResidualsFocalPlane(AnalysisTool):
         self.process.buildActions.statMask.fluxType = "psfFlux"
 
         self.produce.plot = FocalPlanePlot()
-        self.produce.plot.xAxisLabel = "x (focal plane)"
-        self.produce.plot.yAxisLabel = "y (focal plane)"
         self.produce.plot.zAxisLabel = "Mag - Mag$_{mean}$ (mmag)"


### PR DESCRIPTION
Default axis labels include units (mm).