### PR TITLE
DM-42971: Remove pipeline-level overrides

### DIFF
--- a/pipelines/coaddQualityCore.yaml
+++ b/pipelines/coaddQualityCore.yaml
@@ -36,10 +36,7 @@ tasks:
         from lsst.analysis.tools.atools import *
         from lsst.analysis.tools.contexts import *
         from lsst.analysis.tools.actions.plot import *
-  catalogMatchTract:
-    class: lsst.analysis.tools.tasks.astrometricCatalogMatch.AstrometricCatalogMatchTask
-    config:
-      connections.refCatalog: gaia_dr3_20230707
+  catalogMatchTract: lsst.analysis.tools.tasks.astrometricCatalogMatch.AstrometricCatalogMatchTask
   refCatObjectTract:
     class: lsst.analysis.tools.tasks.refCatObjectAnalysis.RefCatObjectAnalysisTask
     config:
@@ -53,11 +50,8 @@ tasks:
         from lsst.analysis.tools.atools import *
         from lsst.analysis.tools.contexts import *
 
-    ## Perform photometric comparison to the reference catalog
-  photometricCatalogMatch:
-    class: lsst.analysis.tools.tasks.photometricCatalogMatch.PhotometricCatalogMatchTask
-    config:
-      connections.refCatalog: ps1_pv3_3pi_20170110
+  # Perform photometric comparison to the reference catalog
+  photometricCatalogMatch: lsst.analysis.tools.tasks.photometricCatalogMatch.PhotometricCatalogMatchTask
   photometricRefCatObjectTract:
     class: lsst.analysis.tools.tasks.refCatObjectPhotometricAnalysis.RefCatObjectPhotometricAnalysisTask
     config:

--- a/python/lsst/analysis/tools/tasks/astrometricCatalogMatch.py
+++ b/python/lsst/analysis/tools/tasks/astrometricCatalogMatch.py
@@ -51,6 +51,7 @@ class AstrometricCatalogMatchConfig(CatalogMatchConfig, pipelineConnections=Cata
         self.referenceCatalogLoader.doApplyColorTerms = False
         self.referenceCatalogLoader.refObjLoader.requireProperMotion = True
         self.referenceCatalogLoader.refObjLoader.anyFilterMapsToThis = "phot_g_mean"
+        self.connections.refCatalog = "gaia_dr3_20230707"
 
 
 class AstrometricCatalogMatchTask(CatalogMatchTask):


### PR DESCRIPTION
for PhotometricCatalogMatchTask and AstrometricCatalogMatchTask. Pipeline levels overrides cannot be overriden by obs packages, and PhotometricCatalogMatchTask was being overriden by the default anyway