### PR TITLE
Tickets/DM-42672: Create FocalPlaneGeometryPlots for biasMean, biasNoise, biasCRNoise, biasShiftCount

### DIFF
--- a/pipelines/exposureCore.yaml
+++ b/pipelines/exposureCore.yaml
@@ -14,6 +14,8 @@ tasks:
       atools.BiasNoisePerAmp.process.buildActions.z.vectorKey: biasNoise
       atools.BiasCrNoisePerAmp: CalibStatisticFocalPlanePlot
       atools.BiasCrNoisePerAmp.process.buildActions.z.vectorKey: biasCrNoise
+      atools.BiasShiftCountPerAmp: CalibStatisticFocalPlanePlot
+      atools.BiasShiftCountPerAmp.process.buildActions.z.vectorKey: biasShiftCount
       atools.ampBiasProfileScatter: CPVerifyQuantityAmpProfileScatterTool
       atools.ampBiasProfileScatter.prep.quantityKey: biasSerialProfile
       atools.ampBiasProfileScatter.produce.plot.suptitle:

--- a/pipelines/exposureCore.yaml
+++ b/pipelines/exposureCore.yaml
@@ -1,11 +1,19 @@
 description: |
-  Core-level plots and metrics for exposure-level data.
+  Tier1 plots to assess validity of calibration exposures.
 tasks:
-  VerifyBias:
-    class: lsst.analysis.tools.tasks.VerifyBiasAnalysisTask
+  analyseBiasCore:
+    class: lsst.analysis.tools.tasks.VerifyCalibAnalysisTask
     config:
-      connections.outputName: VerifyBias
-      atools.ReadNoisePerAmp: MedReadNoiseFocalPlanePlot
+      connections.outputName: biasCore
+      connections.data: verifyBiasResults
+      atools.ReadNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.ReadNoisePerAmp.process.buildActions.z.vectorKey: biasReadNoise
+      atools.MeanBiasPerAmp: CalibStatisticFocalPlanePlot
+      atools.MeanBiasPerAmp.process.buildActions.z.vectorKey: biasMean
+      atools.BiasNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.BiasNoisePerAmp.process.buildActions.z.vectorKey: biasNoise
+      atools.BiasCrNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.BiasCrNoisePerAmp.process.buildActions.z.vectorKey: biasCrNoise
       atools.ampBiasProfileScatter: CPVerifyQuantityAmpProfileScatterTool
       atools.ampBiasProfileScatter.prep.quantityKey: biasSerialProfile
       atools.ampBiasProfileScatter.produce.plot.suptitle:
@@ -17,3 +25,18 @@ tasks:
       python: |
         from lsst.analysis.tools.atools import *
         from lsst.analysis.tools.actions.plot.elements import *
+  analyseDarkCore:
+    class: lsst.analysis.tools.tasks.VerifyCalibAnalysisTask
+    config:
+      connections.outputName: darkCore
+      connections.data: verifyDarkResults
+      atools.ReadNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.ReadNoisePerAmp.process.buildActions.z.vectorKey: darkReadNoise
+      atools.MeanDarkPerAmp: CalibStatisticFocalPlanePlot
+      atools.MeanDarkPerAmp.process.buildActions.z.vectorKey: darkMean
+      atools.DarkNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.DarkNoisePerAmp.process.buildActions.z.vectorKey: darkNoise
+      atools.DarkCrNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.DarkCrNoisePerAmp.process.buildActions.z.vectorKey: darkCrNoise
+      python: |
+        from lsst.analysis.tools.atools import *

--- a/pipelines/exposureCore.yaml
+++ b/pipelines/exposureCore.yaml
@@ -6,16 +6,16 @@ tasks:
     config:
       connections.outputName: biasCore
       connections.data: verifyBiasResults
-      atools.ReadNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.ReadNoisePerAmp.process.buildActions.z.vectorKey: biasReadNoise
-      atools.MeanBiasPerAmp: CalibStatisticFocalPlanePlot
-      atools.MeanBiasPerAmp.process.buildActions.z.vectorKey: biasMean
-      atools.BiasNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.BiasNoisePerAmp.process.buildActions.z.vectorKey: biasNoise
-      atools.BiasCrNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.BiasCrNoisePerAmp.process.buildActions.z.vectorKey: biasCrNoise
-      atools.BiasShiftCountPerAmp: CalibStatisticFocalPlanePlot
-      atools.BiasShiftCountPerAmp.process.buildActions.z.vectorKey: biasShiftCount
+      atools.readNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.readNoisePerAmp.process.buildActions.z.vectorKey: biasReadNoise
+      atools.meanBiasPerAmp: CalibStatisticFocalPlanePlot
+      atools.meanBiasPerAmp.process.buildActions.z.vectorKey: biasMean
+      atools.biasNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.biasNoisePerAmp.process.buildActions.z.vectorKey: biasNoise
+      atools.biasCrNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.biasCrNoisePerAmp.process.buildActions.z.vectorKey: biasCrNoise
+      atools.biasShiftCountPerAmp: CalibStatisticFocalPlanePlot
+      atools.biasShiftCountPerAmp.process.buildActions.z.vectorKey: biasShiftCount
       atools.ampBiasProfileScatter: CPVerifyQuantityAmpProfileScatterTool
       atools.ampBiasProfileScatter.prep.quantityKey: biasSerialProfile
       atools.ampBiasProfileScatter.produce.plot.suptitle:
@@ -32,13 +32,13 @@ tasks:
     config:
       connections.outputName: darkCore
       connections.data: verifyDarkResults
-      atools.ReadNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.ReadNoisePerAmp.process.buildActions.z.vectorKey: darkReadNoise
-      atools.MeanDarkPerAmp: CalibStatisticFocalPlanePlot
-      atools.MeanDarkPerAmp.process.buildActions.z.vectorKey: darkMean
-      atools.DarkNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.DarkNoisePerAmp.process.buildActions.z.vectorKey: darkNoise
-      atools.DarkCrNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.DarkCrNoisePerAmp.process.buildActions.z.vectorKey: darkCrNoise
+      atools.readNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.readNoisePerAmp.process.buildActions.z.vectorKey: darkReadNoise
+      atools.meanDarkPerAmp: CalibStatisticFocalPlanePlot
+      atools.meanDarkPerAmp.process.buildActions.z.vectorKey: darkMean
+      atools.darkNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.darkNoisePerAmp.process.buildActions.z.vectorKey: darkNoise
+      atools.darkCrNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.darkCrNoisePerAmp.process.buildActions.z.vectorKey: darkCrNoise
       python: |
         from lsst.analysis.tools.atools import *

--- a/pipelines/exposureCore.yaml
+++ b/pipelines/exposureCore.yaml
@@ -6,16 +6,17 @@ tasks:
     config:
       connections.outputName: biasCore
       connections.data: verifyBiasResults
-      atools.readNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.readNoisePerAmp.process.buildActions.z.vectorKey: biasReadNoise
+      atools.biasReadNoisePerAmp: CalibStatisticFocalPlanePlot
+      atools.biasReadNoisePerAmp.quantityKey: biasReadNoise
       atools.meanBiasPerAmp: CalibStatisticFocalPlanePlot
-      atools.meanBiasPerAmp.process.buildActions.z.vectorKey: biasMean
+      atools.meanBiasPerAmp.quantityKey: biasMean
       atools.biasNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.biasNoisePerAmp.process.buildActions.z.vectorKey: biasNoise
+      atools.biasNoisePerAmp.quantityKey: biasNoise
       atools.biasCrNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.biasCrNoisePerAmp.process.buildActions.z.vectorKey: biasCrNoise
+      atools.biasCrNoisePerAmp.quantityKey: biasCrNoise
       atools.biasShiftCountPerAmp: CalibStatisticFocalPlanePlot
-      atools.biasShiftCountPerAmp.process.buildActions.z.vectorKey: biasShiftCount
+      atools.biasShiftCountPerAmp.quantityKey: biasShiftCount
+      atools.biasShiftCountPerAmp.unit: count
       atools.ampBiasProfileScatter: CPVerifyQuantityAmpProfileScatterTool
       atools.ampBiasProfileScatter.prep.quantityKey: biasSerialProfile
       atools.ampBiasProfileScatter.produce.plot.suptitle:
@@ -33,12 +34,12 @@ tasks:
       connections.outputName: darkCore
       connections.data: verifyDarkResults
       atools.readNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.readNoisePerAmp.process.buildActions.z.vectorKey: darkReadNoise
+      atools.readNoisePerAmp.quantityKey: darkReadNoise
       atools.meanDarkPerAmp: CalibStatisticFocalPlanePlot
-      atools.meanDarkPerAmp.process.buildActions.z.vectorKey: darkMean
+      atools.meanDarkPerAmp.quantityKey: darkMean
       atools.darkNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.darkNoisePerAmp.process.buildActions.z.vectorKey: darkNoise
+      atools.darkNoisePerAmp.quantityKey: darkNoise
       atools.darkCrNoisePerAmp: CalibStatisticFocalPlanePlot
-      atools.darkCrNoisePerAmp.process.buildActions.z.vectorKey: darkCrNoise
+      atools.darkCrNoisePerAmp.quantityKey: darkCrNoise
       python: |
         from lsst.analysis.tools.atools import *

--- a/python/lsst/analysis/tools/atools/calibration.py
+++ b/python/lsst/analysis/tools/atools/calibration.py
@@ -30,6 +30,7 @@ __all__ = (
     "PtcRowMeanVarianceSlopeFP",
 )
 
+from lsst.pex.config import Field
 from ..actions.plot.focalPlanePlot import FocalPlaneGeometryPlot
 from ..actions.vector import LoadVector
 from ..interfaces import AnalysisTool
@@ -59,6 +60,11 @@ class CalibStatisticFocalPlanePlot(CalibrationTool):
     The median is across multiple bias exposures.
     """
 
+    quantityKey = Field[str](
+        default="biasMean", doc="VectorKey to perform the statistic on and to plot per amp and per detector."
+    )
+    unit = Field[str](default="ADU", doc="Unit of quantity for including on z-axis label.")
+
     def setDefaults(self):
         super().setDefaults()
 
@@ -69,7 +75,8 @@ class CalibStatisticFocalPlanePlot(CalibrationTool):
         self.produce.plot.zAxisLabel = "Median of biasMean"
 
     def finalize(self):
-        zAxislabel = f"{self.produce.plot.statistic} of {self.process.buildActions.z.vectorKey}"
+        self.process.buildActions.z.vectorKey = self.quantityKey
+        zAxislabel = f"{self.produce.plot.statistic} of {self.quantityKey} ({self.unit})"
         self.produce.plot.zAxisLabel = zAxislabel.capitalize()
 
 

--- a/python/lsst/analysis/tools/atools/calibration.py
+++ b/python/lsst/analysis/tools/atools/calibration.py
@@ -70,8 +70,12 @@ class CalibStatisticFocalPlanePlot(AnalysisTool):
         self.process.buildActions.amplifier.vectorKey = "amplifier"
 
         self.produce.plot = FocalPlaneGeometryPlot()
-        self.produce.plot.zAxisLabel = "Med. Readnoise"
         self.produce.plot.statistic = "median"
+        self.produce.plot.zAxisLabel = "Median of biasMean"
+
+    def finalize(self):
+        zAxislabel = f"{self.produce.plot.statistic} of {self.process.buildActions.z.vectorKey}"
+        self.produce.plot.zAxisLabel = zAxislabel.capitalize()
 
 
 class PtcGainFP(CalibrationTool):

--- a/python/lsst/analysis/tools/atools/calibration.py
+++ b/python/lsst/analysis/tools/atools/calibration.py
@@ -53,7 +53,7 @@ class CalibrationTool(AnalysisTool):
         self.produce.plot.statistic = "median"
 
 
-class CalibStatisticFocalPlanePlot(AnalysisTool):
+class CalibStatisticFocalPlanePlot(CalibrationTool):
     """Generates a plot of the focal plane, color-coded according to the
     median of a given measurement (default: "biasMean") on a per-amp basis.
     The median is across multiple bias exposures.
@@ -62,12 +62,7 @@ class CalibStatisticFocalPlanePlot(AnalysisTool):
     def setDefaults(self):
         super().setDefaults()
 
-        self.process.buildActions.z = LoadVector()
         self.process.buildActions.z.vectorKey = "biasMean"
-        self.process.buildActions.detector = LoadVector()
-        self.process.buildActions.detector.vectorKey = "detector"
-        self.process.buildActions.amplifier = LoadVector()
-        self.process.buildActions.amplifier.vectorKey = "amplifier"
 
         self.produce.plot = FocalPlaneGeometryPlot()
         self.produce.plot.statistic = "median"

--- a/python/lsst/analysis/tools/atools/calibration.py
+++ b/python/lsst/analysis/tools/atools/calibration.py
@@ -31,6 +31,7 @@ __all__ = (
 )
 
 from lsst.pex.config import Field
+
 from ..actions.plot.focalPlanePlot import FocalPlaneGeometryPlot
 from ..actions.vector import LoadVector
 from ..interfaces import AnalysisTool
@@ -70,7 +71,6 @@ class CalibStatisticFocalPlanePlot(CalibrationTool):
 
         self.process.buildActions.z.vectorKey = "biasMean"
 
-        self.produce.plot = FocalPlaneGeometryPlot()
         self.produce.plot.statistic = "median"
         self.produce.plot.zAxisLabel = "Median of biasMean"
 

--- a/python/lsst/analysis/tools/atools/calibration.py
+++ b/python/lsst/analysis/tools/atools/calibration.py
@@ -55,8 +55,8 @@ class CalibrationTool(AnalysisTool):
 
 class CalibStatisticFocalPlanePlot(AnalysisTool):
     """Generates a plot of the focal plane, color-coded according to the
-    median bias read noise on a per-amp basis. The median is across
-    multiple bias exposures.
+    median of a given measurement (default: "biasMean") on a per-amp basis.
+    The median is across multiple bias exposures.
     """
 
     def setDefaults(self):

--- a/python/lsst/analysis/tools/atools/calibration.py
+++ b/python/lsst/analysis/tools/atools/calibration.py
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 __all__ = (
-    "MedReadNoiseFocalPlanePlot",
+    "CalibStatisticFocalPlanePlot",
     "PtcGainFP",
     "PtcNoiseFP",
     "PtcA00FP",
@@ -53,7 +53,7 @@ class CalibrationTool(AnalysisTool):
         self.produce.plot.statistic = "median"
 
 
-class MedReadNoiseFocalPlanePlot(AnalysisTool):
+class CalibStatisticFocalPlanePlot(AnalysisTool):
     """Generates a plot of the focal plane, color-coded according to the
     median bias read noise on a per-amp basis. The median is across
     multiple bias exposures.
@@ -63,7 +63,7 @@ class MedReadNoiseFocalPlanePlot(AnalysisTool):
         super().setDefaults()
 
         self.process.buildActions.z = LoadVector()
-        self.process.buildActions.z.vectorKey = "biasReadNoise"
+        self.process.buildActions.z.vectorKey = "biasMean"
         self.process.buildActions.detector = LoadVector()
         self.process.buildActions.detector.vectorKey = "detector"
         self.process.buildActions.amplifier = LoadVector()

--- a/python/lsst/analysis/tools/tasks/calibrationAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/calibrationAnalysis.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 __all__ = (
     "VerifyPtcAnalysisConfig",
     "VerifyPtcAnalysisTask",
-    "VerifyBiasAnalysisConfig",
-    "VerifyBiasAnalysisTask",
+    "VerifyCalibAnalysisConfig",
+    "VerifyCalibAnalysisTask",
 )
 
 from lsst.pipe.base import connectionTypes as cT
@@ -32,7 +32,7 @@ from lsst.pipe.base import connectionTypes as cT
 from ..interfaces import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 
 
-class VerifyBiasAnalysisConnections(
+class VerifyCalibAnalysisConnections(
     AnalysisBaseConnections,
     dimensions=("instrument",),
     defaultTemplates={"inputName": "verifyBiasResults"},
@@ -54,13 +54,13 @@ class VerifyBiasAnalysisConnections(
     )
 
 
-class VerifyBiasAnalysisConfig(AnalysisBaseConfig, pipelineConnections=VerifyBiasAnalysisConnections):
+class VerifyCalibAnalysisConfig(AnalysisBaseConfig, pipelineConnections=VerifyCalibAnalysisConnections):
     pass
 
 
-class VerifyBiasAnalysisTask(AnalysisPipelineTask):
-    ConfigClass = VerifyBiasAnalysisConfig
-    _DefaultName = "verifyBiasAnalysis"
+class VerifyCalibAnalysisTask(AnalysisPipelineTask):
+    ConfigClass = VerifyCalibAnalysisConfig
+    _DefaultName = "verifyCalibAnalysis"
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         # Docs inherited from base class.

--- a/python/lsst/analysis/tools/tasks/calibrationAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/calibrationAnalysis.py
@@ -21,10 +21,10 @@
 from __future__ import annotations
 
 __all__ = (
-    "VerifyPtcAnalysisConfig",
-    "VerifyPtcAnalysisTask",
     "VerifyCalibAnalysisConfig",
     "VerifyCalibAnalysisTask",
+    "VerifyPtcAnalysisConfig",
+    "VerifyPtcAnalysisTask",
 )
 
 from lsst.pipe.base import connectionTypes as cT


### PR DESCRIPTION
I've included `quantityKey` and `unit` as input parameters to `calibration.py`. The reason for the former is to simplify the pipeline.yaml file, while the latter allows for the unit to be included in the dynamically-poduced zAxisLabel.

Please see the [JIRA ticket](https://jira.lsstcorp.org/browse/DM-42672) for plot examples.

Jenkins currently running.