### PR TITLE
DM-43231: Create Analysis Tool to send visitSummary info to sasquatch

### DIFF
--- a/python/lsst/analysis/tools/atools/__init__.py
+++ b/python/lsst/analysis/tools/atools/__init__.py
@@ -1,5 +1,6 @@
 from .amplifierCorrelation import *
 from .astrometricRepeatability import *
+from .calexpMetrics import *
 from .calibration import *
 from .coveragePlots import *
 from .cpVerifyQuantityProfile import *

--- a/python/lsst/analysis/tools/atools/calexpMetrics.py
+++ b/python/lsst/analysis/tools/atools/calexpMetrics.py
@@ -1,0 +1,73 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ("CalexpSummaryMetrics",)
+
+from ..interfaces import AnalysisTool
+
+
+class CalexpSummaryMetrics(AnalysisTool):
+    """
+    Class to load statistics from the summary stats contained with a calexp's
+    metadata and write them to metrics.
+    """
+
+    propagateData: bool = True
+
+    # raCorners and decCorners statistics cannot be written to a metric,
+    # as metrics can only be single-valued (i.e., scalars).
+    _units = {
+        "psfSigma": "pixel",
+        "psfArea": "",  # There is no astropy sq. pixel unit.
+        "psfIxx": "pixel",
+        "psfIyy": "pixel",
+        "psfIxy": "pixel",
+        "ra": "degree",
+        "dec": "degree",
+        "zenithDistance": "degree",
+        "zeroPoint": "mag",
+        "skyBg": "mag",
+        "skyNoise": "mag",
+        "meanVar": "mag",
+        "astromOffsetMean": "arcsec",
+        "astromOffsetStd": "arcsec",
+        "nPsfStar": "",
+        "psfStarDeltaE1Median": "pixel",
+        "psfStarDeltaE2Median": "pixel",
+        "psfStarDeltaE1Scatter": "pixel",
+        "psfStarDeltaE2Scatter": "pixel",
+        "psfStarDeltaSizeMedian": "pixel",
+        "psfStarDeltaSizeScatter": "pixel",
+        "psfStarScaledDeltaSizeScatter": "pixel",
+        "psfTraceRadiusDelta": "pixel",
+        "maxDistToNearestPsf": "deg",
+        "effTime": "s",
+        "effTimePsfSigmaScale": "s",
+        "effTimeSkyBgScale": "s",
+        "effTimeZeroPointScale": "s",
+    }
+
+    def setDefaults(self):
+        super().setDefaults()
+
+        self.prep.keysToLoad = list(self._units.keys())
+        self.produce.metric.units = self._units

--- a/python/lsst/analysis/tools/tasks/__init__.py
+++ b/python/lsst/analysis/tools/tasks/__init__.py
@@ -2,6 +2,7 @@ from .ampToAmpCorrelationAnalysis import *
 from .assocDiaSrcDetectorVisitAnalysis import *
 from .associatedSourcesTractAnalysis import *
 from .astrometricCatalogMatch import *
+from .calexpSummaryAnalysis import *
 from .calibrationAnalysis import *
 from .catalogMatch import *
 from .ccdVisitTableAnalysis import *

--- a/python/lsst/analysis/tools/tasks/calexpSummaryAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/calexpSummaryAnalysis.py
@@ -25,16 +25,16 @@ __all__ = (
     "CalexpSummaryAnalysisTask",
 )
 
+from lsst.pipe.base import InputQuantizedConnection, OutputQuantizedConnection, QuantumContext
 from lsst.pipe.base import connectionTypes as cT
 
-from lsst.pipe.base import InputQuantizedConnection, OutputQuantizedConnection, QuantumContext
 from ..interfaces import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
 
 
 class CalexpSummaryAnalysisConnections(
     AnalysisBaseConnections,
     dimensions=("visit", "band", "detector"),
-    defaultTemplates={"inputName": "calexp", "outputName": "calexpSummary"},
+    defaultTemplates={"inputName": "calexp.summaryStats", "outputName": "calexpSummary"},
 ):
     data = cT.Input(
         doc="Calibrated exposure summary statistics to load from the butler",
@@ -63,7 +63,7 @@ class CalexpSummaryAnalysisTask(AnalysisPipelineTask):
 
         inputs = butlerQC.get(inputRefs)
 
-        summary = inputs["data"].getInfo().getSummaryStats().__dict__
+        summary = inputs["data"].__dict__
 
         outputs = self.run(data=summary)
         butlerQC.put(outputs, outputRefs)

--- a/python/lsst/analysis/tools/tasks/calexpSummaryAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/calexpSummaryAnalysis.py
@@ -1,0 +1,69 @@
+# This file is part of analysis_tools.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = (
+    "CalexpSummaryAnalysisConfig",
+    "CalexpSummaryAnalysisTask",
+)
+
+from lsst.pipe.base import connectionTypes as cT
+
+from lsst.pipe.base import InputQuantizedConnection, OutputQuantizedConnection, QuantumContext
+from ..interfaces import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPipelineTask
+
+
+class CalexpSummaryAnalysisConnections(
+    AnalysisBaseConnections,
+    dimensions=("visit", "band", "detector"),
+    defaultTemplates={"inputName": "calexp", "outputName": "calexpSummary"},
+):
+    data = cT.Input(
+        doc="Calibrated exposure summary statistics to load from the butler",
+        name="calexp.summaryStats",
+        storageClass="ExposureSummaryStats",
+        dimensions=("visit", "band", "detector"),
+        deferLoad=False,
+    )
+
+
+class CalexpSummaryAnalysisConfig(AnalysisBaseConfig, pipelineConnections=CalexpSummaryAnalysisConnections):
+    pass
+
+
+class CalexpSummaryAnalysisTask(AnalysisPipelineTask):
+    ConfigClass = CalexpSummaryAnalysisConfig
+    _DefaultName = "calexpSummary"
+
+    def runQuantum(
+        self,
+        butlerQC: QuantumContext,
+        inputRefs: InputQuantizedConnection,
+        outputRefs: OutputQuantizedConnection,
+    ) -> None:
+        # Docstring inherited.
+
+        inputs = butlerQC.get(inputRefs)
+
+        summary = inputs["data"].getInfo().getSummaryStats().__dict__
+
+        outputs = self.run(data=summary)
+        butlerQC.put(outputs, outputRefs)


### PR DESCRIPTION
This ticket involves changes to two repositories: this repository (analysis_tools) and pipe_tasks. Here, I'm adding a new analysis tool task and atool to extract summary statistics from a calexp's metadata and write them to sasquatch. 