### PR TITLE
DM-43477: Create pipeline yaml file to create calexp summary metrics from existing calexps' summary stats

### DIFF
--- a/pipelines/calexpMetrics.yaml
+++ b/pipelines/calexpMetrics.yaml
@@ -1,0 +1,8 @@
+description: |
+  Metrics created from the analysis of calibrated exposures.
+tasks:
+  calexpSummary:
+    class: lsst.analysis.tools.tasks.CalexpSummaryAnalysisTask
+    config:
+      atools.calexpSummaryMetrics: CalexpSummaryMetrics
+      python: from lsst.analysis.tools.atools import *


### PR DESCRIPTION
Enables the production and writing of metrics generated from an existing calexp's summary statistics.