### PR TITLE
DM-41063: Move trailed source filtering to filterDiaSourceCatalog

### DIFF
--- a/pipelines/apDetectorVisitQualityCore.yaml
+++ b/pipelines/apDetectorVisitQualityCore.yaml
@@ -47,7 +47,7 @@ tasks:
       connections.outputName: trailedDiaSrcCore
       atools.numDiaSourcesAll: NumDiaSourcesSelectionMetric
       atools.numDiaSourcesAll.metricName: numTrailedDiaSrc
-      atools.numDiaSourcesAll.process.calculateActions.countingAction.vectorKey: diaSourceId
+      atools.numDiaSourcesAll.process.calculateActions.countingAction.vectorKey: id
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       python: |

--- a/pipelines/apDetectorVisitQualityCore.yaml
+++ b/pipelines/apDetectorVisitQualityCore.yaml
@@ -47,7 +47,7 @@ tasks:
       connections.outputName: trailedDiaSrcCore
       atools.numDiaSourcesAll: NumDiaSourcesSelectionMetric
       atools.numDiaSourcesAll.metricName: numTrailedDiaSrc
-      atools.numDiaSourcesAll.process.calculateActions.countingAction.vectorKey: id
+      atools.numDiaSourcesAll.process.calculateActions.countingAction.vectorKey: diaSourceId
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
       python: |

--- a/python/lsst/analysis/tools/tasks/trailedDiaSrcDetectorVisitAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/trailedDiaSrcDetectorVisitAnalysis.py
@@ -35,7 +35,7 @@ class TrailedDiaSrcDetectorVisitAnalysisConnections(
     data = connectionTypes.Input(
         doc="Output temporarily storing long trailed diaSources.",
         name="{fakesType}{coaddName}Diff_longTrailedSrc",
-        storageClass="DataFrame",
+        storageClass="ArrowAstropy",
         deferLoad=True,
         dimensions=("visit", "band", "detector"),
     )


### PR DESCRIPTION
With the trailed source filtering moved to `filterdiaSourceCatalog`, its type has changed from pandas dataframe to ArrowAstropy. This required an update to `analysis_tools.`