### PR TITLE
DM-44002: Fix DatasetRef warning when using the analysis_tools reconstructor

### DIFF
--- a/python/lsst/analysis/tools/tasks/reconstructor.py
+++ b/python/lsst/analysis/tools/tasks/reconstructor.py
@@ -88,7 +88,7 @@ def reconstructAnalysisTools(
                     dsName, dataId=dataId, findFirst=True, collections=(collection,)
                 )
             ):
-                container.append(butler.get(ref, collections=(collection,)))
+                container.append(butler.get(ref))
             inputs[name] = container
         else:
             inputs[name] = butler.get(dsName, dataId=dataId, collections=(collection,))


### PR DESCRIPTION
Removed collections keyword from butler.get(ref,...) in tasks/reconstructor.py