### PR TITLE
DM-44302: Implement photometric repeatability metrics and plots in analysis_tools with calib_fluxes

### DIFF
--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -7,6 +7,10 @@ tasks:
       connections.outputName: matchedVisitCore
       atools.stellarPhotometricRepeatability: StellarPhotometricRepeatability
       atools.stellarPhotometricResiduals: StellarPhotometricResidualsFocalPlane
+      atools.stellarPhotometricRepeatabilityCalib: StellarPhotometricRepeatability
+      atools.stellarPhotometricRepeatabilityCalib.fluxType: 'calibFlux'
+      atools.stellarPhotometricResidualsCalib: StellarPhotometricResidualsFocalPlane
+      atools.stellarPhotometricResidualsCalib.fluxType: 'calibFlux'
       atools.stellarAstrometricResidualsRA: StellarAstrometricResidualsRAFocalPlanePlot
       atools.stellarAstrometricResidualsDec: StellarAstrometricResidualsDecFocalPlanePlot
       atools.stellarAstrometricResidualStdDevRA: StellarAstrometricResidualStdDevRAFocalPlanePlot

--- a/python/lsst/analysis/tools/actions/plot/histPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/histPlot.py
@@ -555,10 +555,10 @@ class HistPlot(PlotAction):
         else:
             if self.panels[panel].refRelativeToMedian:
                 reference_value = self.panels[panel].referenceValue + meds[0]
-                reference_label = "${{\\mu_{{ref}}}}$: {}".format(reference_value)
+                reference_label = "${{\\mu_{{ref}}}}$: {:10.3F}".format(reference_value)
             else:
                 reference_value = self.panels[panel].referenceValue
-                reference_label = "${{\\mu_{{ref}}}}$: {}".format(reference_value)
+                reference_label = "${{\\mu_{{ref}}}}$: {:10.3F}".format(reference_value)
             ax2.axvline(reference_value, ls="-", lw=1, c="black", zorder=0, label=reference_label)
         if self.panels[panel].histDensity:
             ref_x = np.arange(panel_range[0], panel_range[1], (panel_range[1] - panel_range[0]) / 100.0)

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -180,7 +180,7 @@ class StellarPhotometricResidualsFocalPlane(AnalysisTool):
         # Apply per-source selection criteria
         self.prep.selectors.bandSelector = BandSelector()
         self.prep.selectors.snSelector = SnSelector()
-        self.prep.selectors.snSelector.fluxType = "psfFlux"
+        self.prep.selectors.snSelector.fluxType = f"{self.fluxType}"
         self.prep.selectors.snSelector.threshold = 50
 
         self.process.buildActions.z = ResidualWithPerGroupStatistic()
@@ -197,7 +197,7 @@ class StellarPhotometricResidualsFocalPlane(AnalysisTool):
 
         self.process.buildActions.statMask = SnSelector()
         self.process.buildActions.statMask.threshold = 200
-        self.process.buildActions.statMask.fluxType = "psfFlux"
+        self.process.buildActions.statMask.fluxType = f"{self.fluxType}"
 
         self.process.calculateActions.photResidTractMedian = MedianAction(vectorKey="z")
         self.process.calculateActions.photResidTractStdev = StdevAction(vectorKey="z")
@@ -211,6 +211,15 @@ class StellarPhotometricResidualsFocalPlane(AnalysisTool):
             "photResidTractStdev": "mmag",
             "photResidTractMedian": "mmag",
         }
+
+    def finalize(self):
+        super().finalize()
+        self.prep.selectors.snSelector.fluxType = f"{self.fluxType}"
+        self.process.buildActions.z.buildAction = ConvertFluxToMag(
+            vectorKey=f"{self.fluxType}",
+            returnMillimags=True,
+        )
+        self.process.buildActions.statMask.fluxType = f"{self.fluxType}"
 
         self.produce.metric.newNames = {
             "photResidTractSigmaMad": "{band}_photResidTractSigmaMad",

--- a/python/lsst/analysis/tools/atools/photometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/photometricRepeatability.py
@@ -180,8 +180,8 @@ class StellarPhotometricResidualsFocalPlane(AnalysisTool):
         # Apply per-source selection criteria
         self.prep.selectors.bandSelector = BandSelector()
         self.prep.selectors.snSelector = SnSelector()
-        self.prep.selectors.snSelector.fluxType = f"{self.fluxType}"
-        self.prep.selectors.snSelector.threshold = 50
+        self.prep.selectors.snSelector.fluxType = "psfFlux"
+        self.prep.selectors.snSelector.threshold = 200
 
         self.process.buildActions.z = ResidualWithPerGroupStatistic()
         self.process.buildActions.z.buildAction = ConvertFluxToMag(
@@ -204,6 +204,7 @@ class StellarPhotometricResidualsFocalPlane(AnalysisTool):
         self.process.calculateActions.photResidTractSigmaMad = SigmaMadAction(vectorKey="z")
 
         self.produce.plot = FocalPlanePlot()
+        self.produce.plot.nBins = 100
         self.produce.plot.zAxisLabel = "Mag - Mag$_{median}$ (mmag)"
 
         self.produce.metric.units = {  # type: ignore
@@ -214,7 +215,6 @@ class StellarPhotometricResidualsFocalPlane(AnalysisTool):
 
     def finalize(self):
         super().finalize()
-        self.prep.selectors.snSelector.fluxType = f"{self.fluxType}"
         self.process.buildActions.z.buildAction = ConvertFluxToMag(
             vectorKey=f"{self.fluxType}",
             returnMillimags=True,


### PR DESCRIPTION
This ticket creates new metrics and plots that calculate photometric repeatability using `calibFlux` instead of `psfFlux`. The comparison between these is informative to the Photometric Calibration Science Unit in assessing different contributions to the error budget.

Implementing the focal plane plot required updating the `StellarPhotometricResidualsFocalPlane` class so that it will correctly apply config overrides.

Finally, I added formatting to the `histPlot` routine to make the reference_label formatting not have too many digits after the decimal.