### PR TITLE
DM-44583: Use setattr instead of object.__setattr__.

### DIFF
--- a/python/lsst/analysis/tools/interfaces/_task.py
+++ b/python/lsst/analysis/tools/interfaces/_task.py
@@ -179,8 +179,7 @@ class AnalysisBaseConnections(
                 doc="Dynamic connection for plotting",
                 dimensions=self.dimensions,
             )
-            object.__setattr__(self, name, outConnection)
-            self.outputs.add(name)
+            setattr(self, name, outConnection)
 
 
 def _timestampValidator(value: str) -> bool:


### PR DESCRIPTION
The base connection's class doesn't actually override any attribute-setting hooks, but if it did, we'd want it to fire.

We also don't need to explicitly update the self.<connection-type> sets anymore, as those are handled by the metaclass.