### PR TITLE
DM-46642: Run matchVisitQuality tasks on outputs of isolatedStarSourceAssociation.

### DIFF
--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -88,6 +88,8 @@ tasks:
     config:
       connections.sourceCatalogs: preSourceTable_visit
       connections.outputName: matchedPreVisitCore
+      connections.associatedSources: isolated_star_presources
+      connections.associatedSourcesInputName: isolated_star_presources
       # Proper motion catalogs are not available for `preSourceTables`
       applyAstrometricCorrections: false
       atools.stellarAstrometricSelfRepeatabilityRA: AstrometricRepeatability


### PR DESCRIPTION
After the calibration refactoer PreSources and Sources are based on two separate rounds of detection.
isolatedStarAssociation is run on both separately and yields two sets of match catalogs.

analyzeMatchedVisitCore is based on: isolated_star_sources
analyzeMatchedPreVisitCore is based on:  isolated_star_presources