### PR TITLE
DM-46188: Add connection templates to refCatSourcePhotometricAnalysis.

### DIFF
--- a/python/lsst/analysis/tools/tasks/refCatSourcePhotometricAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/refCatSourcePhotometricAnalysis.py
@@ -30,11 +30,15 @@ from ..interfaces import AnalysisBaseConfig, AnalysisBaseConnections, AnalysisPi
 class RefCatSourcePhotometricAnalysisConnections(
     AnalysisBaseConnections,
     dimensions=("visit",),
-    defaultTemplates={"outputName": "sourceTable_visit_ps1_pv3_3pi_20170110_match_photom"},
+    defaultTemplates={
+        "targetCatalog": "sourceTable_visit",
+        "refCatalog": "ps1_pv3_3pi_20170110",
+        "outputName": "sourceTable_visit_ps1_pv3_3pi_20170110_match_photom",
+    },
 ):
     data = ct.Input(
         doc="Tract based object table to load from the butler",
-        name="sourceTable_visit_ps1_pv3_3pi_20170110_match_photom",
+        name="{targetCatalog}_{refCatalog}_match_photom",
         storageClass="ArrowAstropy",
         deferLoad=True,
         dimensions=("visit",),


### PR DESCRIPTION
All other refCat*Analysis tasks have these, so this one should do.