### PR TITLE
DM-47010: Change default to assume preSources used for matching

### DIFF
--- a/pipelines/matchedVisitQualityCore.yaml
+++ b/pipelines/matchedVisitQualityCore.yaml
@@ -88,8 +88,6 @@ tasks:
     config:
       connections.sourceCatalogs: preSourceTable_visit
       connections.outputName: matchedPreVisitCore
-      connections.associatedSources: isolated_star_presources
-      connections.associatedSourcesInputName: isolated_star_presources
       # Proper motion catalogs are not available for `preSourceTables`
       applyAstrometricCorrections: false
       atools.stellarAstrometricSelfRepeatabilityRA: AstrometricRepeatability

--- a/python/lsst/analysis/tools/atools/astrometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/astrometricRepeatability.py
@@ -219,7 +219,8 @@ class AstrometricRelativeRepeatability(AnalysisTool):
         self.prep.selectors.bandSelector = BandSelector()
         # Following what was done in faro, only sources with S/N between 50
         # and 50000 are included. The other filtering that was done in faro
-        # is now covered by only including sources from isolated_star_sources.
+        # is now covered by only including sources from
+        # isolated_star_presources.
         self.prep.selectors.snSelector = SnSelector()
         self.prep.selectors.snSelector.threshold = 50
         self.prep.selectors.snSelector.maxSN = 50000

--- a/python/lsst/analysis/tools/tasks/associatedSourcesTractAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/associatedSourcesTractAnalysis.py
@@ -42,8 +42,8 @@ class AssociatedSourcesTractAnalysisConnections(
     AnalysisBaseConnections,
     dimensions=("skymap", "tract", "instrument"),
     defaultTemplates={
-        "outputName": "isolated_star_sources",
-        "associatedSourcesInputName": "isolated_star_sources",
+        "outputName": "isolated_star_presources",
+        "associatedSourcesInputName": "isolated_star_presources",
     },
 ):
     sourceCatalogs = ct.Input(

--- a/python/lsst/analysis/tools/tasks/sourceObjectTableAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/sourceObjectTableAnalysis.py
@@ -147,7 +147,7 @@ class SourceObjectTableAnalysisConnections(
     defaultTemplates={
         "inputName": "sourceTable_visit",
         "inputCoaddName": "deep",
-        "associatedSourcesInputName": "isolated_star_sources",
+        "associatedSourcesInputName": "isolated_star_presources",
         "outputName": "sourceObjectTable",
     },
 ):


### PR DESCRIPTION
Use isolated_star_presources for matches and sourceTable_visit for measurements.