### PR TITLE
DM-44743: Fix crash when trying to zoom on an empty map

### DIFF
--- a/python/lsst/analysis/tools/actions/plot/propertyMapPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/propertyMapPlot.py
@@ -344,8 +344,8 @@ class PropertyMapPlot(PlotAction):
                         sp.draw_hspmap(mapData, zoom=False)
                     else:
                         sp.draw_hspmap(mapData, zoom=zoom)
-                    sp.set_xlabel("RA")
-                    sp.set_ylabel("Dec")
+                    sp.ax.set_xlabel("RA")
+                    sp.ax.set_ylabel("Dec")
                     cbar = sp.draw_colorbar(location="right", fraction=0.15, aspect=colorBarAspect, pad=0)
                     cbar.ax.tick_params(labelsize=colorbarTickLabelSize)
                     cbarText = (

--- a/python/lsst/analysis/tools/actions/plot/propertyMapPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/propertyMapPlot.py
@@ -338,7 +338,12 @@ class PropertyMapPlot(PlotAction):
                         extent=extent,
                         rcparams=rcparams,
                     )
-                    sp.draw_hspmap(mapData, zoom=zoom)
+                    # Work around skyproj bug that will fail to zoom on empty
+                    # map.
+                    if mapData.n_valid == 0:
+                        sp.draw_hspmap(mapData, zoom=False)
+                    else:
+                        sp.draw_hspmap(mapData, zoom=zoom)
                     sp.set_xlabel("RA")
                     sp.set_ylabel("Dec")
                     cbar = sp.draw_colorbar(location="right", fraction=0.15, aspect=colorBarAspect, pad=0)


### PR DESCRIPTION
This also fixes deprecated usage in skyproj.