### PR TITLE
DM-48019: Add explicit input for sourceTable_visit in analyzeSourceTableCore

### DIFF
--- a/pipelines/visitQualityCore.yaml
+++ b/pipelines/visitQualityCore.yaml
@@ -4,6 +4,7 @@ tasks:
   analyzeSourceTableCore:
     class: lsst.analysis.tools.tasks.SourceTableVisitAnalysisTask
     config:
+      connections.inputName: sourceTable_visit
       connections.outputName: sourceTableCore
       atools.skyFluxVisitStatisticMetric: SkyFluxStatisticMetric
       atools.skyFluxVisitStatisticMetric.applyContext: VisitContext

--- a/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/sourceTableVisitAnalysis.py
@@ -34,7 +34,7 @@ class SourceTableVisitAnalysisConnections(
 ):
     data = ct.Input(
         doc="Visit based source table to load from the butler",
-        name="sourceTable_visit",
+        name="{inputName}",
         storageClass="ArrowAstropy",
         dimensions=("visit", "band"),
         deferLoad=True,


### PR DESCRIPTION
This avoids mistakenly leaving the default input unchanged when reusing for `preSources` (instead of `sources`).