### PR TITLE
DM-48655: Add pandas index to visit table on read if needed.

### DIFF
--- a/python/lsst/analysis/tools/tasks/sourceObjectTableAnalysis.py
+++ b/python/lsst/analysis/tools/tasks/sourceObjectTableAnalysis.py
@@ -315,6 +315,11 @@ class SourceObjectTableAnalysisTask(AnalysisPipelineTask):
         visit : `int`
             Identifier of the isolatedSources' visit.
         """
+        if visitTable.index.name is None:
+            # The expected index may or may not be set, depending on whether
+            # the table was written originally as a DataFrame or something else
+            # Parquet-friendly.
+            visitTable.set_index("visitId", inplace=True)
         sourceMjd = visitTable.loc[visit]["expMidptMJD"]
 
         # Get target date from reference catalog


### PR DESCRIPTION
This exact logic was needed in another method called applyAstrometricCorrections on a different task; I'm a little concerned there might be some code duplication there, but I don't have time to dig too deeply there.