### PR TITLE
DM-47181: Modify hist plot output format for Astrometry.

### DIFF
--- a/python/lsst/analysis/tools/actions/plot/histPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/histPlot.py
@@ -340,7 +340,7 @@ class HistPlot(PlotAction):
             ncols = 2
         nrows = int(np.ceil(num_panels / ncols))
 
-        gs = GridSpec(nrows, ncols, left=0.12, right=0.99, bottom=0.1, top=0.88, wspace=0.31, hspace=0.45)
+        gs = GridSpec(nrows, ncols, left=0.12, right=0.88, bottom=0.1, top=0.88, wspace=0.41, hspace=0.45)
 
         axs = []
         counter = 0
@@ -626,7 +626,7 @@ class HistPlot(PlotAction):
             legend_handles,
             legend_labels,
             loc="lower left",
-            bbox_to_anchor=(0.0, yAnchor),
+            bbox_to_anchor=(-0.25, yAnchor),
             ncol=4,
             handletextpad=-0.25,
             fontsize=legend_font_size,

--- a/python/lsst/analysis/tools/atools/astrometricRepeatability.py
+++ b/python/lsst/analysis/tools/atools/astrometricRepeatability.py
@@ -253,10 +253,16 @@ class AstrometricRelativeRepeatability(AnalysisTool):
         self.produce.plot.panels["panel_sep"] = HistPanel()
         self.produce.plot.panels["panel_sep"].hists = dict(separationResiduals="Source separations")
         self.produce.plot.panels["panel_sep"].label = "Separation Distances (marcsec)"
+        self.produce.plot.panels["panel_sep"].lowerRange = 0
+        self.produce.plot.panels["panel_sep"].upperRange = 80
+        self.produce.plot.panels["panel_sep"].rangeType = "fixed"
 
         self.produce.plot.panels["panel_rms"] = HistPanel()
         self.produce.plot.panels["panel_rms"].hists = dict(rmsDistances="Object RMS")
         self.produce.plot.panels["panel_rms"].label = "Per-Object RMS (marcsec)"
+        self.produce.plot.panels["panel_rms"].lowerRange = 0
+        self.produce.plot.panels["panel_rms"].upperRange = 80
+        self.produce.plot.panels["panel_rms"].rangeType = "fixed"
         # TODO: DM-39163 add reference lines for ADx, AMx, and AFx.
 
     def finalize(self):


### PR DESCRIPTION
When I was looking at plots output for Astrometry, label were out of the figure. This is fixing that and I fixed limit of plot to make easier to compare between different run. 