### PR TITLE
DM-46249-hotfix3 : Upload analysis_tools metrics from ap_verify so they can be retrieved in Chronograf

### DIFF
--- a/python/lsst/analysis/tools/bin/verifyToSasquatch.py
+++ b/python/lsst/analysis/tools/bin/verifyToSasquatch.py
@@ -24,7 +24,6 @@ __all__ = [
 ]
 
 import argparse
-import copy
 import datetime
 import logging
 from collections import defaultdict
@@ -34,6 +33,7 @@ import lsst.verify
 from lsst.analysis.tools.interfaces import MetricMeasurementBundle
 from lsst.analysis.tools.interfaces.datastore import SasquatchDispatcher
 from lsst.daf.butler import Butler, DataCoordinate, DatasetRef
+from lsst.utils.argparsing import AppendDict
 
 logging.basicConfig()
 _LOG = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ def makeParser():
     )
     parser.add_argument(
         "--extra",
-        action=_AppendDict,
+        action=AppendDict,
         help="Extra field (in the form key=value) to be added to any records "
         "uploaded to Sasquatch. See SasquatchDispatcher.dispatch and "
         ".dispatchRef for more details. The --extra argument can be passed "
@@ -104,61 +104,6 @@ def makeParser():
     api_group.add_argument("--token", default="na", help="Authentication token for the proxy server.")
 
     return parser
-
-
-class _AppendDict(argparse.Action):
-    """An action analogous to the build-in 'append' that appends to a `dict`
-    instead of a `list`.
-
-    Inputs are assumed to be strings in the form "key=value"; any input that
-    does not contain exactly one "=" character is invalid. If the default value
-    is non-empty, the default key-value pairs may be overwritten by values from
-    the command line.
-    """
-
-    def __init__(
-        self,
-        option_strings,
-        dest,
-        nargs=None,
-        const=None,
-        default=None,
-        type=None,
-        choices=None,
-        required=False,
-        help=None,
-        metavar=None,
-    ):
-        if default is None:
-            default = {}
-        if not isinstance(default, Mapping):
-            argname = option_strings if option_strings else metavar if metavar else dest
-            raise TypeError(f"Default for {argname} must be a mapping or None, got {default!r}.")
-        super().__init__(option_strings, dest, nargs, const, default, type, choices, required, help, metavar)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        # argparse doesn't make defensive copies, so namespace.dest may be
-        # the same object as self.default. Do the copy ourselves and avoid
-        # modifying the object previously in namespace.dest.
-        mapping = copy.copy(getattr(namespace, self.dest))
-
-        # Sometimes values is a copy of default instead of an input???
-        if isinstance(values, Mapping):
-            mapping.update(values)
-        else:
-            # values may be either a string or list of strings, depending on
-            # nargs. Unsafe to test for Sequence, because a scalar string
-            # passes.
-            if not isinstance(values, list):
-                values = [values]
-            for value in values:
-                vars = value.split("=")
-                if len(vars) != 2:
-                    raise ValueError(f"Argument {value!r} does not match format 'key=value'.")
-                mapping[vars[0]] = vars[1]
-
-        # Other half of the defensive copy.
-        setattr(namespace, self.dest, mapping)
 
 
 def _bundle_metrics(

--- a/tests/test_verifyToSasquatch.py
+++ b/tests/test_verifyToSasquatch.py
@@ -19,13 +19,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import argparse
 import tempfile
 import unittest
 
 import astropy.units as u
 import lsst.daf.butler.tests as butlerTests
-from lsst.analysis.tools.bin.verifyToSasquatch import _AppendDict, _bundle_metrics
+from lsst.analysis.tools.bin.verifyToSasquatch import _bundle_metrics
 from lsst.analysis.tools.interfaces import MetricMeasurementBundle
 from lsst.daf.butler import CollectionType, DataCoordinate
 from lsst.verify import Measurement
@@ -176,103 +175,3 @@ class VerifyToSasquatchTestSuite(unittest.TestCase):
         refs = self.butler.registry.queryDatasets("metricvalue_nopackage_notAMetric", collections=...)
         with self.assertRaises(ValueError):
             _bundle_metrics(self.butler, refs)
-
-
-class AppendDictTestSuite(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.testbed = argparse.ArgumentParser()
-
-    def test_default_none_positional(self):
-        self.testbed.add_argument("test", action=_AppendDict, nargs="*")
-
-        namespace = self.testbed.parse_args([])
-        self.assertEqual(namespace.test, {})
-
-        namespace = self.testbed.parse_args("baz=bak".split())
-        self.assertEqual(namespace.test, {"baz": "bak"})
-
-    def test_default_none_keyword(self):
-        self.testbed.add_argument("--test", action=_AppendDict)
-
-        namespace = self.testbed.parse_args([])
-        self.assertEqual(namespace.test, {})
-
-        namespace = self.testbed.parse_args("--test baz=bak".split())
-        self.assertEqual(namespace.test, {"baz": "bak"})
-
-    def test_default_empty_positional(self):
-        self.testbed.add_argument("test", action=_AppendDict, default={}, nargs="*")
-
-        namespace = self.testbed.parse_args([])
-        self.assertEqual(namespace.test, {})
-
-        namespace = self.testbed.parse_args("baz=bak".split())
-        self.assertEqual(namespace.test, {"baz": "bak"})
-
-    def test_default_empty_keyword(self):
-        self.testbed.add_argument("--test", action=_AppendDict, default={})
-
-        namespace = self.testbed.parse_args([])
-        self.assertEqual(namespace.test, {})
-
-        namespace = self.testbed.parse_args("--test baz=bak".split())
-        self.assertEqual(namespace.test, {"baz": "bak"})
-
-    def test_default_non_empty_positional(self):
-        self.testbed.add_argument("test", action=_AppendDict, default={"foo": "bar"}, nargs="*")
-
-        namespace = self.testbed.parse_args([])
-        self.assertEqual(namespace.test, {"foo": "bar"})
-
-        namespace = self.testbed.parse_args("baz=bak".split())
-        self.assertEqual(namespace.test, {"foo": "bar", "baz": "bak"})
-
-        namespace = self.testbed.parse_args("foo=fum".split())
-        self.assertEqual(namespace.test, {"foo": "fum"})
-
-    def test_default_non_empty_keyword(self):
-        self.testbed.add_argument("--test", action=_AppendDict, default={"foo": "bar"})
-
-        namespace = self.testbed.parse_args([])
-        self.assertEqual(namespace.test, {"foo": "bar"})
-
-        namespace = self.testbed.parse_args("--test baz=bak".split())
-        self.assertEqual(namespace.test, {"foo": "bar", "baz": "bak"})
-
-        namespace = self.testbed.parse_args("--test foo=fum".split())
-        self.assertEqual(namespace.test, {"foo": "fum"})
-
-    def test_default_invalid(self):
-        with self.assertRaises(TypeError):
-            self.testbed.add_argument("test", action=_AppendDict, default="bovine")
-        with self.assertRaises(TypeError):
-            self.testbed.add_argument("test", action=_AppendDict, default=[])
-
-    def test_multi_append(self):
-        self.testbed.add_argument("--test", action=_AppendDict)
-
-        namespace = self.testbed.parse_args("--test foo=bar --test baz=bak".split())
-        self.assertEqual(namespace.test, {"foo": "bar", "baz": "bak"})
-
-    def test_multi_nargs_append(self):
-        self.testbed.add_argument("--test", action=_AppendDict, nargs="*")
-
-        namespace = self.testbed.parse_args("--test foo=bar fee=fum --test baz=bak --test".split())
-        self.assertEqual(namespace.test, {"foo": "bar", "fee": "fum", "baz": "bak"})
-
-    def test_emptyvalue(self):
-        self.testbed.add_argument("test", action=_AppendDict)
-
-        namespace = self.testbed.parse_args("foo=".split())
-        self.assertEqual(namespace.test, {"foo": ""})
-
-    def test_nopair(self):
-        self.testbed.add_argument("test", action=_AppendDict)
-
-        with self.assertRaises(ValueError):
-            self.testbed.parse_args("foo".split())
-
-        with self.assertRaises(ValueError):
-            self.testbed.parse_args("assertion=beauty=truth".split())


### PR DESCRIPTION
This PR is moving `_AppendDict` class in `verifyToSasquatch.py` to be in `lsst.utils` package, so it can be widely used.