### PR TITLE
DM-49727-v29: Remove objectEpochTable from visitAnalysis

### DIFF
--- a/pipelines/visitQualityCore.yaml
+++ b/pipelines/visitQualityCore.yaml
@@ -31,8 +31,6 @@ tasks:
     class: lsst.analysis.tools.tasks.refCatSourcePhotometricAnalysis.RefCatSourcePhotometricAnalysisTask
     config:
       file: $ANALYSIS_TOOLS_DIR/config/refCatSourcePhotometricCore.py
-  objectEpochTable:
-    class: lsst.analysis.tools.tasks.ObjectEpochTableTask
   sourceObjectMatch:
     class: lsst.analysis.tools.tasks.SourceObjectTableAnalysisTask
   calexpSummary:


### PR DESCRIPTION
This isn't an analysis task and its replacement will be run along with coadd-level tasks in existing pipelines.