### PR TITLE
DM-52115: Handle exceptions from all SasquatchDispatcher's network operations

### DIFF
--- a/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
@@ -251,7 +251,7 @@ class SasquatchDispatcher:
                 return True
             else:
                 log.error(
-                    "Unknown error occured creating kafka topic %s %s",
+                    "Unknown error occurred creating kafka topic %s %s",
                     e.response.status_code,
                     e.response.reason,
                 )

--- a/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
@@ -669,7 +669,7 @@ class SasquatchDispatcher:
 
         Raises
         ------
-        SasquatchDispatchPartialFailure
+        SasquatchDispatchPartialFailure, SasquatchDispatchFailure
             Raised if there were any errors in dispatching a bundle.
         """
         if id is None:
@@ -768,7 +768,7 @@ class SasquatchDispatcher:
 
         Raises
         ------
-        SasquatchDispatchPartialFailure
+        SasquatchDispatchPartialFailure, SasquatchDispatchFailure
             Raised if there were any errors in dispatching a bundle.
         """
         # Parse the relevant info out of the dataset ref.

--- a/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
@@ -208,9 +208,8 @@ class SasquatchDispatcher:
                 cluster_id = r.json()["data"][0]["cluster_id"]
                 self._cluster_id = str(cluster_id)
             r.raise_for_status()
-        except requests.RequestException:
-            log.error("Could not retrieve the cluster id for the specified url")
-            raise SasquatchDispatchFailure("Could not retrieve the cluster id for the specified url")
+        except requests.RequestException as e:
+            raise SasquatchDispatchFailure("Could not retrieve the cluster id for the specified url") from e
 
     def _create_topic(self, topic_name: str) -> bool:
         """Create a kafka topic in Sasquatch.


### PR DESCRIPTION
This PR broadens the request error handling in `_dispatcher.py` to include cluster and topic setup (which are more likely than the upload to encounter network problems because they run first) and to include failure modes that don't return an HTTP response.