### PR TITLE
DM-52558: Fix property plot crash when there are no valid values in the map

### DIFF
--- a/python/lsst/analysis/tools/actions/keyedData/stellarLocusFit.py
+++ b/python/lsst/analysis/tools/actions/keyedData/stellarLocusFit.py
@@ -235,7 +235,12 @@ def perpDistance(p1, p2, points):
     points = list(points)
     if len(points) == 0:
         raise ValueError("Must provied a non-empty zip() list of points.")
-    dists = np.cross(p2 - p1, points - p1) / np.linalg.norm(p2 - p1)
+
+    # Recommendation from numpy docs for 2d cross product.
+    def cross2d(x, y):
+        return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
+    dists = cross2d(p2 - p1, points - p1) / np.linalg.norm(p2 - p1)
 
     return dists
 

--- a/python/lsst/analysis/tools/actions/plot/propertyMapPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/propertyMapPlot.py
@@ -600,7 +600,7 @@ class PerTractPropertyMapPlot(PlotAction):
 
             # Calculate weights for each bin to ensure that the peak of the
             # histogram reaches 1.
-            if np.ptp(values) < 1e-12:
+            if len(values) == 0 or np.ptp(values) < 1e-12:
                 # np.histogram cannot use 100 bins if no variance in values
                 weights = np.ones_like(values) / values.size
                 nBinsHist = 1


### PR DESCRIPTION
This also fixes a numpy deprecation warning.