### PR TITLE
DM-52576: LSSTCam DRP error in photometricRefCatObjectTract: "cannot access local variable 'meds' where it is not associated with a value"

### DIFF
--- a/python/lsst/analysis/tools/actions/plot/histPlot.py
+++ b/python/lsst/analysis/tools/actions/plot/histPlot.py
@@ -564,7 +564,11 @@ class HistPlot(PlotAction):
                 reference_value = self.panels[panel].referenceValue
                 reference_label = "${{\\mu_{{ref}}}}$: {:10.3F}".format(reference_value)
             ax2.axvline(reference_value, ls="-", lw=1, c="black", zorder=0, label=reference_label)
-        if self.panels[panel].histDensity:
+        if (
+            self.panels[panel].histDensity
+            and (panel_range[1] - panel_range[0] != 0)
+            and all(np.isfinite(panel_range))
+        ):
             ref_x = np.arange(panel_range[0], panel_range[1], (panel_range[1] - panel_range[0]) / 100.0)
             ref_mean = self.panels[panel].referenceValue
             ref_std = 1.0

--- a/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
+++ b/python/lsst/analysis/tools/actions/plot/scatterplotWithTwoHists.py
@@ -452,6 +452,7 @@ class ScatterPlotWithTwoHists(PlotAction):
         ax = fig.add_subplot(gs[1:, :-1])
 
         binThresh = 5
+        min_n_xs_for_stats = 10
 
         yBinsOut = []
         linesForLegend = []
@@ -544,7 +545,7 @@ class ScatterPlotWithTwoHists(PlotAction):
             n_xs = np.count_nonzero(np.isfinite(xs))
             if n_xs <= 1 or not (np.isfinite(sigMadYs) and sigMadYs > 0.0):
                 continue
-            elif n_xs < 10:
+            elif n_xs < min_n_xs_for_stats:
                 xs = [nanMedian(xs)]
                 sigMads = np.array([nanSigmaMad(ys)])
                 ys = np.array([nanMedian(ys)])
@@ -800,7 +801,8 @@ class ScatterPlotWithTwoHists(PlotAction):
             plotMed = np.nan
 
         # Ignore types below pending making this not working my accident
-        if len(xs) < 2:  # type: ignore
+        # If len(xs) < min_n_xs_for_stats then `meds` doesn't exist.
+        if len(xs) < min_n_xs_for_stats:  # type: ignore
             meds = [nanMedian(ys)]  # type: ignore
         if self.yLims:
             ax.set_ylim(self.yLims[0], self.yLims[1])  # type: ignore


### PR DESCRIPTION
This is branched-off another bug-fix ticket branch (DM-52046) so by reviewing this PR you'll review them both at the same time. Both are small edits, so it should be straightforward. There's one commit each:
DM-52046: Add catch for no valid range in histPlot
DM-52576: Reconcile low stats threshold in scatterPlotWithTwoHists