### PR TITLE
DM-55998: Hard code Metrics Bundle support into datastore

### DIFF
--- a/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_dispatcher.py
@@ -21,7 +21,14 @@
 
 from __future__ import annotations
 
-__all__ = ("SasquatchDispatchPartialFailure", "SasquatchDispatchFailure", "SasquatchDispatcher")
+__all__ = (
+    "DispatchableMetricBundle",
+    "MetricMeasurement",
+    "MetricName",
+    "SasquatchDispatchFailure",
+    "SasquatchDispatchPartialFailure",
+    "SasquatchDispatcher",
+)
 
 import calendar
 import datetime
@@ -29,9 +36,9 @@ import json
 import logging
 import math
 import re
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import ItemsView, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 from uuid import UUID, uuid4
 
 import numpy as np
@@ -42,9 +49,6 @@ from lsst.resources import ResourcePath
 from lsst.utils.packages import getEnvironmentPackages
 
 from ...utils import http_client
-
-if TYPE_CHECKING:
-    from .. import MetricMeasurementBundle
 
 """Sasquatch datastore"""
 
@@ -81,6 +85,57 @@ class SasquatchDispatchFailure(RuntimeError):
     """
 
     pass
+
+
+@runtime_checkable
+class MetricName(Protocol):
+    """The interface required of the name of a measured metric."""
+
+    metric: str
+    """Name of the metric, without any package qualification."""
+
+
+@runtime_checkable
+class MetricMeasurement(Protocol):
+    """The interface required of a single metric measurement."""
+
+    metric_name: MetricName
+    """Identifier of the metric that was measured."""
+
+    notes: Mapping[str, Any]
+    """Annotations for the measurement, keyed by ``<metric>.<note>``."""
+
+    json: Mapping[str, Any]
+    """The measurement as a mapping with ``metric`` and ``value`` keys.
+
+    This is an attribute rather than a method so that a property such as
+    the one on `lsst.verify.Measurement` satisfies it. It is unrelated to
+    the ``json()`` method of
+    `~lsst.analysis.tools.interfaces.MetricMeasurementBundle`.
+    """
+
+
+@runtime_checkable
+class DispatchableMetricBundle(Protocol):
+    """The interface required of a dataset dispatched to Sasquatch.
+
+    Any in-memory type structurally matching this protocol can be sent to
+    Sasquatch, whatever storage class the butler associates it with.
+    """
+
+    metricNamePrefix: str
+    """String prepended to each metric name to form the topic name."""
+
+    def items(self) -> ItemsView[str, Sequence[MetricMeasurement]]:
+        """Return the measurements, grouped by metric name.
+
+        Returns
+        -------
+        items : `~collections.abc.ItemsView`
+            Must be a re-iterable view rather than a one-shot iterator,
+            because callers are permitted to traverse it more than once.
+        """
+        ...
 
 
 def _tag2VersionTime(productStr: str) -> tuple[str, float]:
@@ -349,7 +404,7 @@ class SasquatchDispatcher:
                 log.error("Unsupported type %s, skipping record", type(value))
                 return {}
 
-    def _handleReferencePackage(self, meta: MutableMapping, bundle: MetricMeasurementBundle) -> None:
+    def _handleReferencePackage(self, meta: MutableMapping, bundle: DispatchableMetricBundle) -> None:
         """Check to see if there is a reference package.
 
         if there is a reference package, determine the datetime associated with
@@ -361,7 +416,7 @@ class SasquatchDispatcher:
         meta : `MutableMapping`
             A mapping which corresponds to fields which should be encoded in
             all records.
-        bundle : `MetricMeasurementBundle`
+        bundle : `DispatchableMetricBundle`
             The bundled metrics
         """
         ref_package, package_version, package_timestamp = "", "", 0.0
@@ -381,7 +436,7 @@ class SasquatchDispatcher:
         meta["reference_package_version"] = package_version
         meta["reference_package_timestamp"] = package_timestamp
 
-    def _handleTimes(self, meta: MutableMapping, bundle: MetricMeasurementBundle, run: str) -> None:
+    def _handleTimes(self, meta: MutableMapping, bundle: DispatchableMetricBundle, run: str) -> None:
         """Add times to the meta fields mapping.
 
         Add all appropriate timestamp fields to the meta field mapping. These
@@ -396,7 +451,7 @@ class SasquatchDispatcher:
         meta : `MutableMapping`
             A mapping which corresponds to fields which should be encoded in
             all records.
-        bundle : `MetricMeasurementBundle`
+        bundle : `DispatchableMetricBundle`
             The bundled metrics
         run : `str`
             The `~lsst.daf.butler.Butler` collection where the
@@ -452,7 +507,7 @@ class SasquatchDispatcher:
         meta: MutableMapping,
         identifierFields: Mapping[str, Any] | None,
         datasetIdentifier: str | None,
-        bundle: MetricMeasurementBundle,
+        bundle: DispatchableMetricBundle,
     ) -> None:
         """Add an identifier to the meta record mapping.
 
@@ -479,7 +534,7 @@ class SasquatchDispatcher:
             each record will belong to one combination of such.
         datasetIdentifier : `str` or `None`
             A string which will be used in creating unique identifier tags.
-        bundle : `MetricMeasurementBundle`
+        bundle : `DispatchableMetricBundle`
             The bundle containing metric values to upload.
         """
         identifier: str
@@ -500,7 +555,7 @@ class SasquatchDispatcher:
 
     def _prepareBundle(
         self,
-        bundle: MetricMeasurementBundle,
+        bundle: DispatchableMetricBundle,
         run: str,
         datasetType: str,
         timestamp: datetime.datetime | None = None,
@@ -514,7 +569,7 @@ class SasquatchDispatcher:
 
         Parameters
         ----------
-        bundle : `MetricMeasurementBundle`
+        bundle : `DispatchableMetricBundle`
             The bundle containing metric values to upload.
         run : `str`
             The run name to associate with these metric values. If this bundle
@@ -628,7 +683,7 @@ class SasquatchDispatcher:
 
     def dispatch(
         self,
-        bundle: MetricMeasurementBundle,
+        bundle: DispatchableMetricBundle,
         run: str,
         datasetType: str,
         timestamp: datetime.datetime | None = None,
@@ -641,7 +696,7 @@ class SasquatchDispatcher:
 
         Parameters
         ----------
-        bundle : `MetricMeasurementBundle`
+        bundle : `DispatchableMetricBundle`
             The bundle containing metric values to upload.
         run : `str`
             The run name to associate with these metric values. If this bundle
@@ -747,7 +802,7 @@ class SasquatchDispatcher:
 
     def dispatchRef(
         self,
-        bundle: MetricMeasurementBundle,
+        bundle: DispatchableMetricBundle,
         ref: DatasetRef,
         timestamp: datetime.datetime | None = None,
         extraFields: Mapping | None = None,
@@ -758,7 +813,7 @@ class SasquatchDispatcher:
 
         Parameters
         ----------
-        bundle : `MetricMeasurementBundle`
+        bundle : `DispatchableMetricBundle`
             The bundle containing metric values to upload.
         ref : `DatasetRef`
             The `Butler` dataset ref corresponding to the input

--- a/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.daf.butler import DatasetRef, DatasetTypeNotSupportedError, StorageClass
 from lsst.daf.butler.datastore import DatasetRefURIs, DatastoreConfig, DatastoreOpaqueTable
+from lsst.daf.butler.datastore.constraints import Constraints, ConstraintsConfig
 from lsst.daf.butler.datastore.generic_base import GenericBaseDatastore
 from lsst.daf.butler.datastore.record_data import DatastoreRecordData
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
@@ -64,9 +65,18 @@ class SasquatchDatastore(GenericBaseDatastore):
         Unused parameter.
     """
 
-    defaultConfigFile: ClassVar[str | None] = "sasquatchDatastore.yaml"
-    """Path to configuration defaults. Accessed within the ``configs`` resource
-    or relative to a search path. Can be None if no defaults specified.
+    defaultConfigFile: ClassVar[str | None] = "datastores/sasquatchDatastore.yaml"
+    """Path of datastore-specific configuration file to be included in
+    searches when building butler configurations. Relative to each entry of
+    ``DAF_BUTLER_CONFIG_PATH``.
+    """
+
+    builtinConstraints: ClassVar[Mapping[str, list[str]]] = {"accept": ["MetricMeasurementBundle"]}
+    """Constraints the datastore imposes on itself.
+
+    The dispatcher can only serialize metric bundles, so these types are
+    always accepted. Configuration can add further accepted types but can
+    not remove these.
     """
 
     restProxyUrl: str
@@ -107,6 +117,15 @@ class SasquatchDatastore(GenericBaseDatastore):
     ):
         super().__init__(config, bridgeManager)
 
+        # Datastore.__init__ builds constraints purely from configuration,
+        # which leaves the datastore accepting everything when no override
+        # file is found. Fold in the types this datastore can actually
+        # handle so that a missing or incomplete config can not widen them.
+        self.constraints = Constraints(
+            self._merged_constraints(self.config.get("constraints")),
+            universe=bridgeManager.universe,
+        )
+
         # Name ourselves either using an explicit name or a name
         # derived from the (unexpanded) root.
         self.name = self.config.get("name", "{}@{}".format(type(self).__name__, self.config["restProxyUrl"]))
@@ -134,6 +153,37 @@ class SasquatchDatastore(GenericBaseDatastore):
         self.extra_fields = extra_fields if extra_fields else None
 
         self._dispatcher = SasquatchDispatcher(self.restProxyUrl, self.accessToken, self.namespace)
+
+    @classmethod
+    def _merged_constraints(cls, configured: Config | None) -> ConstraintsConfig:
+        """Combine the built-in constraints with any from configuration.
+
+        Parameters
+        ----------
+        configured : `lsst.daf.butler.Config` or `None`
+            The ``constraints`` section of the datastore configuration, if
+            any.
+
+        Returns
+        -------
+        constraints : `ConstraintsConfig`
+            The built-in accepted types unioned with those from
+            configuration, along with any configured rejections.
+
+        Notes
+        -----
+        Accepted types are unioned rather than replaced so that a
+        configuration that omits them, or that is never found on the search
+        path, can not widen the datastore to types the dispatcher can not
+        serialize. A configuration can therefore add accepted types but not
+        remove the built-in ones.
+        """
+        merged = ConstraintsConfig(dict(cls.builtinConstraints))
+        if configured is not None:
+            merged["accept"] = sorted(set(merged["accept"]) | set(configured.get("accept", [])))
+            if "reject" in configured:
+                merged["reject"] = list(configured["reject"])
+        return merged
 
     @classmethod
     def _create_from_config(

--- a/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
+++ b/python/lsst/analysis/tools/interfaces/datastore/_sasquatchDatastore.py
@@ -26,17 +26,23 @@ __all__ = ("SasquatchDatastore",)
 import logging
 import os
 from collections.abc import Collection, Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, get_protocol_members
 
 from lsst.daf.butler import DatasetRef, DatasetTypeNotSupportedError, StorageClass
 from lsst.daf.butler.datastore import DatasetRefURIs, DatastoreConfig, DatastoreOpaqueTable
-from lsst.daf.butler.datastore.constraints import Constraints, ConstraintsConfig
 from lsst.daf.butler.datastore.generic_base import GenericBaseDatastore
 from lsst.daf.butler.datastore.record_data import DatastoreRecordData
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
 from lsst.resources import ResourcePath, ResourcePathExpression
+from lsst.utils.introspection import get_full_type_name
 
-from . import SasquatchDispatcher, SasquatchDispatchFailure, SasquatchDispatchPartialFailure
+from . import (
+    DispatchableMetricBundle,
+    MetricMeasurement,
+    SasquatchDispatcher,
+    SasquatchDispatchFailure,
+    SasquatchDispatchPartialFailure,
+)
 
 if TYPE_CHECKING:
     from lsst.daf.butler import Config, DatasetProvenance, DatasetType, LookupKey
@@ -63,20 +69,21 @@ class SasquatchDatastore(GenericBaseDatastore):
         Object that manages the interface between `Registry` and datastores.
     butlerRoot : `str`, optional
         Unused parameter.
+
+    Notes
+    -----
+    Which storage classes reach this datastore is controlled entirely by the
+    ``constraints`` section of its configuration, so a site can accept its
+    own metric types without modifying this package. Configuration can not
+    say whether a storage class's Python type is one the dispatcher
+    understands, so `put` additionally checks the in-memory object against
+    `DispatchableMetricBundle` and `MetricMeasurement`.
     """
 
     defaultConfigFile: ClassVar[str | None] = "datastores/sasquatchDatastore.yaml"
     """Path of datastore-specific configuration file to be included in
     searches when building butler configurations. Relative to each entry of
     ``DAF_BUTLER_CONFIG_PATH``.
-    """
-
-    builtinConstraints: ClassVar[Mapping[str, list[str]]] = {"accept": ["MetricMeasurementBundle"]}
-    """Constraints the datastore imposes on itself.
-
-    The dispatcher can only serialize metric bundles, so these types are
-    always accepted. Configuration can add further accepted types but can
-    not remove these.
     """
 
     restProxyUrl: str
@@ -117,15 +124,6 @@ class SasquatchDatastore(GenericBaseDatastore):
     ):
         super().__init__(config, bridgeManager)
 
-        # Datastore.__init__ builds constraints purely from configuration,
-        # which leaves the datastore accepting everything when no override
-        # file is found. Fold in the types this datastore can actually
-        # handle so that a missing or incomplete config can not widen them.
-        self.constraints = Constraints(
-            self._merged_constraints(self.config.get("constraints")),
-            universe=bridgeManager.universe,
-        )
-
         # Name ourselves either using an explicit name or a name
         # derived from the (unexpanded) root.
         self.name = self.config.get("name", "{}@{}".format(type(self).__name__, self.config["restProxyUrl"]))
@@ -155,37 +153,6 @@ class SasquatchDatastore(GenericBaseDatastore):
         self._dispatcher = SasquatchDispatcher(self.restProxyUrl, self.accessToken, self.namespace)
 
     @classmethod
-    def _merged_constraints(cls, configured: Config | None) -> ConstraintsConfig:
-        """Combine the built-in constraints with any from configuration.
-
-        Parameters
-        ----------
-        configured : `lsst.daf.butler.Config` or `None`
-            The ``constraints`` section of the datastore configuration, if
-            any.
-
-        Returns
-        -------
-        constraints : `ConstraintsConfig`
-            The built-in accepted types unioned with those from
-            configuration, along with any configured rejections.
-
-        Notes
-        -----
-        Accepted types are unioned rather than replaced so that a
-        configuration that omits them, or that is never found on the search
-        path, can not widen the datastore to types the dispatcher can not
-        serialize. A configuration can therefore add accepted types but not
-        remove the built-in ones.
-        """
-        merged = ConstraintsConfig(dict(cls.builtinConstraints))
-        if configured is not None:
-            merged["accept"] = sorted(set(merged["accept"]) | set(configured.get("accept", [])))
-            if "reject" in configured:
-                merged["reject"] = list(configured["reject"])
-        return merged
-
-    @classmethod
     def _create_from_config(
         cls,
         config: DatastoreConfig,
@@ -201,21 +168,69 @@ class SasquatchDatastore(GenericBaseDatastore):
     def bridge(self) -> DatastoreRegistryBridge:
         return self._bridge
 
+    @staticmethod
+    def _check_conforms(dataset: Any, protocol: type, description: str) -> None:
+        """Check that an object provides the interface the dispatcher needs.
+
+        Parameters
+        ----------
+        dataset : `object`
+            The in-memory object to inspect.
+        protocol : `type`
+            The runtime-checkable protocol the object must satisfy.
+        description : `str`
+            Human readable description of the object's role, used in the
+            error message.
+
+        Raises
+        ------
+        DatasetTypeNotSupportedError
+            Raised if the object does not provide the interface. This is
+            the exception a chained datastore expects when a datastore
+            cannot handle a dataset, so raising it lets the chain move on
+            to the next datastore rather than failing the whole put.
+        """
+        if isinstance(dataset, protocol):
+            return
+        missing = sorted(name for name in get_protocol_members(protocol) if not hasattr(dataset, name))
+        raise DatasetTypeNotSupportedError(
+            f"{description} of type {get_full_type_name(dataset)} can not be dispatched to "
+            f"Sasquatch: missing {', '.join(missing)}"
+        )
+
     def put(
         self, inMemoryDataset: Any, ref: DatasetRef, *, provenance: DatasetProvenance | None = None
     ) -> None:
-        if self.constraints.isAcceptable(ref):
-            try:
-                self._dispatcher.dispatchRef(inMemoryDataset, ref, extraFields=self.extra_fields)
-            except SasquatchDispatchFailure:
-                log.warning("Failed to dispatch metric bundle to Sasquatch.")
-            except SasquatchDispatchPartialFailure:
-                log.warning("Only some of the metrics were successfully dispatched to Sasquatch.")
-        else:
+        if not self.constraints.isAcceptable(ref):
             log.debug("Could not put dataset type %s with Sasquatch datastore", ref.datasetType)
             raise DatasetTypeNotSupportedError(
                 f"Could not put dataset type {ref.datasetType} with Sasquatch datastore"
             )
+
+        # Configuration controls which storage classes reach this datastore,
+        # but says nothing about whether their Python types can actually be
+        # serialized, so check the object itself against the dispatcher's
+        # interface.
+        self._check_conforms(inMemoryDataset, DispatchableMetricBundle, "Dataset")
+
+        # Spot check the first measurement rather than every one: a
+        # non-conforming type is almost always a whole class that a site has
+        # misconfigured, not one stray element. A bundle whose later
+        # measurements are malformed still reaches the dispatcher, which logs
+        # and skips the records it can not parse.
+        first = next(
+            (measurement for _, measurements in inMemoryDataset.items() for measurement in measurements),
+            None,
+        )
+        if first is not None:
+            self._check_conforms(first, MetricMeasurement, "Measurement")
+
+        try:
+            self._dispatcher.dispatchRef(inMemoryDataset, ref, extraFields=self.extra_fields)
+        except SasquatchDispatchFailure:
+            log.warning("Failed to dispatch metric bundle to Sasquatch.")
+        except SasquatchDispatchPartialFailure:
+            log.warning("Only some of the metrics were successfully dispatched to Sasquatch.")
 
     def put_new(self, in_memory_dataset: Any, dataset_ref: DatasetRef) -> Mapping[str, DatasetRef]:
         # Docstring inherited from the base class.

--- a/python/lsst/analysis/tools/interfaces/datastore/sasquatchDatastore.yaml
+++ b/python/lsst/analysis/tools/interfaces/datastore/sasquatchDatastore.yaml
@@ -1,4 +1,0 @@
-cls: lsst.analysis.tools.interfaces.datastore.SasquatchDatastore
-constraints:
-  accept:
-    - MetricMeasurementBundle

--- a/tests/test_sasquatchDatastore.py
+++ b/tests/test_sasquatchDatastore.py
@@ -28,8 +28,8 @@ import astropy.units as u
 
 import lsst.daf.butler.tests as butlerTests
 from lsst.analysis.tools.interfaces import MetricMeasurementBundle
-from lsst.analysis.tools.interfaces.datastore import SasquatchDispatcher
-from lsst.daf.butler import CollectionType, Config
+from lsst.analysis.tools.interfaces.datastore import SasquatchDatastore, SasquatchDispatcher
+from lsst.daf.butler import CollectionType, Config, DatasetTypeNotSupportedError
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
 from lsst.verify import Measurement
 
@@ -72,6 +72,28 @@ class SasquatchDatastoreTest(unittest.TestCase):
 
         mock_method.assert_called()
         self.assertIs(mock_method.call_args[0][0], bundle)
+
+    def test_rejects_unsupported_dataset_type(self):
+        """The datastore must reject types the dispatcher can not serialize
+        even though its configuration declares no constraints.
+        """
+        butlerTests.addDatasetType(
+            self.butler, "NotAMetric", {"instrument", "visit", "detector"}, "StructuredDataDict"
+        )
+        with self.assertRaises(DatasetTypeNotSupportedError):
+            self.butler.put({"a": 1}, "NotAMetric", run="run1", instrument="DummyCam", visit=42, detector=2)
+
+    def test_configured_constraints_extend_builtin(self):
+        """Configured constraints add to the built-in accepted types rather
+        than replacing them.
+        """
+        self.assertEqual(SasquatchDatastore._merged_constraints(None)["accept"], ["MetricMeasurementBundle"])
+
+        merged = SasquatchDatastore._merged_constraints(
+            Config({"accept": ["OtherBundle"], "reject": ["Unwanted"]})
+        )
+        self.assertEqual(merged["accept"], ["MetricMeasurementBundle", "OtherBundle"])
+        self.assertEqual(merged["reject"], ["Unwanted"])
 
     def test_explicit_timestamp_version(self):
         dispatcher = SasquatchDispatcher("http://test.local", "na")

--- a/tests/test_sasquatchDatastore.py
+++ b/tests/test_sasquatchDatastore.py
@@ -28,13 +28,33 @@ import astropy.units as u
 
 import lsst.daf.butler.tests as butlerTests
 from lsst.analysis.tools.interfaces import MetricMeasurementBundle
-from lsst.analysis.tools.interfaces.datastore import SasquatchDatastore, SasquatchDispatcher
+from lsst.analysis.tools.interfaces.datastore import (
+    DispatchableMetricBundle,
+    MetricMeasurement,
+    MetricName,
+    SasquatchDispatcher,
+)
 from lsst.daf.butler import CollectionType, Config, DatasetTypeNotSupportedError
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
 from lsst.verify import Measurement
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
-CONFIG_FILE = os.path.join(TESTDIR, "config", "butler-sasquatch.yaml")
+
+
+class DuckMetricBundle:
+    """A metric bundle from outside this package.
+
+    Implements the dispatcher interface without inheriting from
+    `MetricMeasurementBundle`, standing in for the type a site other
+    than Rubin might configure this datastore to accept.
+    """
+
+    def __init__(self, data=None):
+        self._data = dict(data or {})
+        self.metricNamePrefix = ""
+
+    def items(self):
+        return self._data.items()
 
 
 class SasquatchDatastoreTest(unittest.TestCase):
@@ -44,6 +64,7 @@ class SasquatchDatastoreTest(unittest.TestCase):
         config = Config()
         config["datastore", "cls"] = "lsst.analysis.tools.interfaces.datastore.SasquatchDatastore"
         config["datastore", "restProxyUrl"] = "https://example.com/sasquatch-rest-proxy"
+        config["storageClasses", "DuckMetricBundle"] = {"pytype": f"{__name__}.DuckMetricBundle"}
 
         dataIds = {
             "instrument": ["DummyCam"],
@@ -73,27 +94,62 @@ class SasquatchDatastoreTest(unittest.TestCase):
         mock_method.assert_called()
         self.assertIs(mock_method.call_args[0][0], bundle)
 
+    def test_put_duck_typed_bundle(self):
+        """A type meeting the protocol dispatches whatever its storage
+        class is called, so sites outside Rubin can configure their own.
+        """
+        butlerTests.addDatasetType(
+            self.butler, "DuckMetrics", {"instrument", "visit", "detector"}, "DuckMetricBundle"
+        )
+        m = Measurement("nopackage.fancyMetric", 42.2 * u.s)
+        bundle = DuckMetricBundle({"m": [m]})
+
+        with patch.object(SasquatchDispatcher, "dispatchRef") as mock_method:
+            self.butler.put(bundle, "DuckMetrics", run="run1", instrument="DummyCam", visit=42, detector=2)
+
+        mock_method.assert_called()
+        self.assertIs(mock_method.call_args[0][0], bundle)
+
+    def test_rejects_non_conforming_measurements(self):
+        """A bundle holding things that are not measurements is rejected
+        before dispatch rather than failing inside the dispatcher.
+        """
+        butlerTests.addDatasetType(
+            self.butler, "DuckMetrics", {"instrument", "visit", "detector"}, "DuckMetricBundle"
+        )
+        bundle = DuckMetricBundle({"m": ["not a measurement"]})
+
+        with patch.object(SasquatchDispatcher, "dispatchRef") as mock_method:
+            with self.assertRaises(DatasetTypeNotSupportedError):
+                self.butler.put(
+                    bundle, "DuckMetrics", run="run1", instrument="DummyCam", visit=42, detector=2
+                )
+
+        mock_method.assert_not_called()
+
+    def test_put_bundle_with_no_measurements(self):
+        """A bundle with nothing to measure has nothing to check and is
+        dispatched unchanged.
+        """
+        butlerTests.addDatasetType(
+            self.butler, "DuckMetrics", {"instrument", "visit", "detector"}, "DuckMetricBundle"
+        )
+        bundle = DuckMetricBundle({"empty": []})
+
+        with patch.object(SasquatchDispatcher, "dispatchRef") as mock_method:
+            self.butler.put(bundle, "DuckMetrics", run="run1", instrument="DummyCam", visit=42, detector=2)
+
+        mock_method.assert_called()
+
     def test_rejects_unsupported_dataset_type(self):
-        """The datastore must reject types the dispatcher can not serialize
-        even though its configuration declares no constraints.
+        """A storage class the configuration accepts is still rejected when
+        its Python type does not provide the dispatcher's interface.
         """
         butlerTests.addDatasetType(
             self.butler, "NotAMetric", {"instrument", "visit", "detector"}, "StructuredDataDict"
         )
-        with self.assertRaises(DatasetTypeNotSupportedError):
+        with self.assertRaisesRegex(DatasetTypeNotSupportedError, "metricNamePrefix"):
             self.butler.put({"a": 1}, "NotAMetric", run="run1", instrument="DummyCam", visit=42, detector=2)
-
-    def test_configured_constraints_extend_builtin(self):
-        """Configured constraints add to the built-in accepted types rather
-        than replacing them.
-        """
-        self.assertEqual(SasquatchDatastore._merged_constraints(None)["accept"], ["MetricMeasurementBundle"])
-
-        merged = SasquatchDatastore._merged_constraints(
-            Config({"accept": ["OtherBundle"], "reject": ["Unwanted"]})
-        )
-        self.assertEqual(merged["accept"], ["MetricMeasurementBundle", "OtherBundle"])
-        self.assertEqual(merged["reject"], ["Unwanted"])
 
     def test_explicit_timestamp_version(self):
         dispatcher = SasquatchDispatcher("http://test.local", "na")
@@ -112,6 +168,25 @@ class SasquatchDatastoreTest(unittest.TestCase):
         dispatcher._handleTimes(meta, bundle, "localRun")
         dt = datetime.datetime(2023, 7, 28, 16, 51, 2, tzinfo=datetime.UTC)
         self.assertEqual(meta["timestamp"], dt.timestamp())
+
+
+class DispatchProtocolTest(unittest.TestCase):
+    """Tests for the structural types describing the dispatcher's interface."""
+
+    def test_bundle_accepts_metric_measurement_bundle(self):
+        self.assertIsInstance(MetricMeasurementBundle(), DispatchableMetricBundle)
+
+    def test_bundle_rejects_plain_dict(self):
+        """A `dict` has ``items`` but no ``metricNamePrefix``."""
+        self.assertNotIsInstance({"a": 1}, DispatchableMetricBundle)
+
+    def test_measurement_accepts_verify_measurement(self):
+        measurement = Measurement("nopackage.fancyMetric", 42.2 * u.s)
+        self.assertIsInstance(measurement, MetricMeasurement)
+        self.assertIsInstance(measurement.metric_name, MetricName)
+
+    def test_measurement_rejects_unrelated_object(self):
+        self.assertNotIsInstance(object(), MetricMeasurement)
 
 
 if __name__ == "__main__":

--- a/ups/analysis_tools.table
+++ b/ups/analysis_tools.table
@@ -17,4 +17,3 @@ setupRequired(skymap)
 # See https://dmtn-001.lsst.io for details on LSST_LIBRARY_PATH.
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
-envPrepend(DAF_BUTLER_CONFIG_PATH, ${PRODUCT_DIR}/python/lsst/analysis/tools/interfaces/datastore)


### PR DESCRIPTION
Rather than relying on this package to provide an overrides configuration that specifies only metrics bundles can be accepted, hard code this knowledge into the package and allow external configuration to add to the list of accepted duck-typed storage classes.

Removes the local DAF_BUTLER_CONFIG_PATH setting and standardizes the override search name to match that expected from other datastores.